### PR TITLE
Don't try to daemonize on windows (fixes #3)

### DIFF
--- a/config_manager.go
+++ b/config_manager.go
@@ -152,6 +152,8 @@ func (cm *ConfigManager) parseFlags() {
 	pflag.IntVarP(&cm.Flags.DestPort, "dest-port", "p", 0, "Destination syslog port")
 	if utils.CanDaemonize {
 		pflag.BoolVarP(&cm.Flags.NoDaemonize, "no-detach", "D", false, "Don't daemonize and detach from the terminal")
+	} else {
+		cm.Flags.NoDaemonize = true
 	}
 	pflag.StringVarP(&cm.Flags.Facility, "facility", "f", "user", "Facility")
 	pflag.StringVar(&cm.Flags.Hostname, "hostname", "", "Local hostname to send from")


### PR DESCRIPTION
This pull request fixes #3 by changing the windows default to not daemonize.

The library we use to provide daemonization doesn't support windows so this is the best we can do without lots and lots of work. At least this allows the program to run on Windows.
