### PR TITLE
Check PID file

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,6 +19,10 @@
 			"Rev": "7f0625dbb54fef2cfba674bc0dfc6c37d34bad27"
 		},
 		{
+			"ImportPath": "github.com/nightlyone/lockfile",
+			"Rev": "7a08cf6d6554e10fc9fb6dba15b1ea3a08ce6bcd"
+		},
+		{
 			"ImportPath": "github.com/ogier/pflag",
 			"Rev": "fc2d9a0ef658fa4e4c319939fd6f4b6becfccb48"
 		},

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -2,4 +2,4 @@ This directory tree is generated automatically by godep.
 
 Please do not edit.
 
-See https://github.com/kr/godep for more information.
+See https://github.com/tools/godep for more information.

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/.gitignore
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/.gitignore
@@ -1,0 +1,27 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# popular temporaries
+.err
+.out
+.diff
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/.gitmodules
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "git-hooks"]
+	path = git-hooks
+	url = https://github.com/nightlyone/git-hooks

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/.travis.yml
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/LICENSE
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012 Ingo Oeser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/README.md
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/README.md
@@ -1,0 +1,52 @@
+lockfile
+=========
+Handle locking via pid files.
+
+[![Build Status][1]][2]
+
+[1]: https://secure.travis-ci.org/nightlyone/lockfile.png
+[2]: http://travis-ci.org/nightlyone/lockfile
+
+
+
+install
+-------
+Install [Go 1][3], either [from source][4] or [with a prepackaged binary][5].
+
+Then run
+
+	go get github.com/nightlyone/lockfile
+
+[3]: http://golang.org
+[4]: http://golang.org/doc/install/source
+[5]: http://golang.org/doc/install
+
+LICENSE
+-------
+BSD
+
+documentation
+-------------
+[package documentation at go.pkgdoc.org](http://go.pkgdoc.org/github.com/nightlyone/lockfile)
+
+install
+-------------------
+	go get github.com/nightlyone/lockfile
+
+
+contributing
+============
+
+Contributions are welcome. Please open an issue or send me a pull request for a dedicated branch.
+Make sure the git commit hooks show it works.
+
+git commit hooks
+-----------------------
+enable commit hooks via
+
+        cd .git ; rm -rf hooks; ln -s ../git-hooks hooks ; cd ..
+
+
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/nightlyone/lockfile/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/lockfile.go
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/lockfile.go
@@ -1,0 +1,142 @@
+// Handle pid file based locking.
+package lockfile
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type Lockfile string
+
+var (
+	ErrBusy        = errors.New("Locked by other process") // If you get this, retry after a short sleep might help
+	ErrNeedAbsPath = errors.New("Lockfiles must be given as absolute path names")
+	ErrInvalidPid  = errors.New("Lockfile contains invalid pid for system")
+	ErrDeadOwner   = errors.New("Lockfile contains pid of process not existent on this system anymore")
+)
+
+// Describe a new filename located at path. It is expected to be an absolute path
+func New(path string) (Lockfile, error) {
+	if !filepath.IsAbs(path) {
+		return Lockfile(""), ErrNeedAbsPath
+	}
+	return Lockfile(path), nil
+}
+
+// Who owns the lockfile?
+func (l Lockfile) GetOwner() (*os.Process, error) {
+	name := string(l)
+
+	// Ok, see, if we have a stale lockfile here
+	content, err := ioutil.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+
+	var pid int
+	_, err = fmt.Sscanln(string(content), &pid)
+	if err != nil {
+		return nil, err
+	}
+
+	// try hard for pids. If no pid, the lockfile is junk anyway and we delete it.
+	if pid > 0 {
+		p, err := os.FindProcess(pid)
+		if err != nil {
+			return nil, err
+		}
+		err = p.Signal(os.Signal(syscall.Signal(0)))
+		if err == nil {
+			return p, nil
+		}
+		errno, ok := err.(syscall.Errno)
+		if !ok {
+			return nil, err
+		}
+
+		switch errno {
+		case syscall.ESRCH:
+			return nil, ErrDeadOwner
+		case syscall.EPERM:
+			return p, nil
+		default:
+			return nil, err
+		}
+	} else {
+		return nil, ErrInvalidPid
+	}
+	panic("Not reached")
+}
+
+// Try to get Lockfile lock. Returns nil, if successful and and error describing the reason, it didn't work out.
+// Please note, that existing lockfiles containing pids of dead processes and lockfiles containing no pid at all
+// are deleted.
+func (l Lockfile) TryLock() error {
+	name := string(l)
+
+	// This has been checked by New already. If we trigger here,
+	// the caller didn't use New and re-implemented it's functionality badly.
+	// So panic, that he might find this easily during testing.
+	if !filepath.IsAbs(string(name)) {
+		panic(ErrNeedAbsPath)
+	}
+
+	tmplock, err := ioutil.TempFile(filepath.Dir(name), "")
+	if err != nil {
+		return err
+	} else {
+		defer tmplock.Close()
+		defer os.Remove(tmplock.Name())
+	}
+
+	_, err = tmplock.WriteString(fmt.Sprintf("%d\n", os.Getpid()))
+	if err != nil {
+		return err
+	}
+
+	// return value intentionally ignored, as ignoring it is part of the algorithm
+	_ = os.Link(tmplock.Name(), name)
+
+	fiTmp, err := os.Lstat(tmplock.Name())
+	if err != nil {
+		return err
+	}
+	fiLock, err := os.Lstat(name)
+	if err != nil {
+		return err
+	}
+
+	// Success
+	if os.SameFile(fiTmp, fiLock) {
+		return nil
+	}
+
+	_, err = l.GetOwner()
+	switch err {
+	default:
+		// Other errors -> defensively fail and let caller handle this
+		return err
+	case nil:
+		return ErrBusy
+	case ErrDeadOwner, ErrInvalidPid:
+		// cases we can fix below
+	}
+
+	// clean stale/invalid lockfile
+	err = os.Remove(name)
+	if err != nil {
+		return err
+	}
+
+	// now that we cleaned up the stale lockfile, let's recurse
+	return l.TryLock()
+}
+
+// Release a lock again. Returns any error that happend during release of lock.
+func (l Lockfile) Unlock() error {
+	return os.Remove(string(l))
+}

--- a/Godeps/_workspace/src/github.com/nightlyone/lockfile/lockfile_test.go
+++ b/Godeps/_workspace/src/github.com/nightlyone/lockfile/lockfile_test.go
@@ -1,0 +1,26 @@
+package lockfile_test
+
+import (
+	lockfile "."
+	"fmt"
+)
+
+func ExampleLockfile() {
+	lock, err := lockfile.New("/tmp/lock.me.now.lck")
+	if err != nil {
+		fmt.Println("Cannot init lock. reason: %v", err)
+		panic(err)
+	}
+	err = lock.TryLock()
+
+	// Error handling is essential, as we only try to get the lock.
+	if err != nil {
+		fmt.Println("Cannot lock \"%v\", reason: %v", lock, err)
+		panic(err)
+	}
+
+	defer lock.Unlock()
+
+	fmt.Println("Do stuff under lock")
+	// Output: Do stuff under lock
+}


### PR DESCRIPTION
This pull request fixes our PID file behavior. With this change, when daemonizing remote_syslog2 will check if the process listed in the pid file is running, and refuse to start if so.

We're using the [nightlyone/lockfile](https://github.com/nightlyone/lockfile) package, as previously discussed with Eric.
