### PR TITLE
Changed min duration to 1 & added code to accept an int in addition to duration

### DIFF
--- a/config_manager.go
+++ b/config_manager.go
@@ -85,14 +85,17 @@ func (r *RefreshInterval) SetStr(value string) error {
 	return r.SetDuration(d)
 }
 
+// Implements pflag's Value interface
 func (r *RefreshInterval) Set(value string) error {
 	return r.SetStr(value)
 }
 
+// Implements pflag's Value interface
 func (r *RefreshInterval) String() string {
 	return fmt.Sprint(*r)
 }
 
+// Implements go-yaml's Setter interface
 func (r *RefreshInterval) SetYAML(tag string, value interface{}) bool {
 	var err error
 
@@ -115,6 +118,7 @@ func (r *RefreshInterval) SetYAML(tag string, value interface{}) bool {
 
 type RegexCollection []*regexp.Regexp
 
+// Implements pflag's Value interface
 func (r *RegexCollection) Set(value string) error {
 	exp, err := regexp.Compile(value)
 	if err != nil {
@@ -124,10 +128,12 @@ func (r *RegexCollection) Set(value string) error {
 	return nil
 }
 
+// Implements pflag's Value interface
 func (r *RegexCollection) String() string {
 	return fmt.Sprint(*r)
 }
 
+// Implements go-yaml's Setter interface
 func (r *RegexCollection) SetYAML(tag string, value interface{}) bool {
 	items, ok := value.([]interface{})
 

--- a/config_manager.go
+++ b/config_manager.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/ogier/pflag"
@@ -17,7 +18,7 @@ import (
 )
 
 const (
-	MinimumRefreshInterval = (time.Duration(10) * time.Second)
+	MinimumRefreshInterval = (time.Duration(1) * time.Second)
 	DefaultConfigFile      = "/etc/log_files.yml"
 )
 
@@ -64,14 +65,21 @@ func (r *RefreshInterval) String() string {
 }
 
 func (r *RefreshInterval) Set(value string) error {
-	d, err := time.ParseDuration(value)
+	var d time.Duration
+	var err error
 
-	if err != nil {
-		return err
+	i, err := strconv.ParseUint(value, 10, 64)
+	if err == nil {
+		d = time.Duration(i) * time.Second
+	} else {
+		d, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
 	}
 
 	if d < MinimumRefreshInterval {
-		return fmt.Errorf("refresh interval must be greater than %s", MinimumRefreshInterval)
+		return fmt.Errorf("refresh interval must be greater than or equal to %s", MinimumRefreshInterval)
 	}
 	r.Duration = d
 	return nil

--- a/config_manager.go
+++ b/config_manager.go
@@ -98,7 +98,7 @@ func (r *RefreshInterval) SetYAML(tag string, value interface{}) bool {
 
 	switch val := value.(type) {
 	default:
-		panic(fmt.Sprintf("Unexpected type \"%T\" in RefreshInterval.Set ", val))
+		panic(fmt.Sprintf("Unexpected type \"%T\" in RefreshInterval.SetYAML", val))
 
 	case string:
 		err = r.SetStr(val)


### PR DESCRIPTION
This could be confusing if someone expects the value to be an int but accidentally adds extra characters. For example:

```
remote_syslog -D --new-file-check-interval=1q
invalid argument "1q" for --new-file-check-interval=1q: time: unknown unit q in duration 1q
```

Might be worth fully switching over to int. @eric what do you think?
