### PR TITLE
Added network as a dependency

### DIFF
--- a/examples/remote_syslog.init.d
+++ b/examples/remote_syslog.init.d
@@ -2,8 +2,8 @@
 
 ### BEGIN INIT INFO
 # Provides: remote_syslog
-# Required-Start: $remote_fs $syslog
-# Required-Stop: $remote_fs $syslog
+# Required-Start: $network $remote_fs $syslog
+# Required-Stop: $network $remote_fs $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Start and Stop


### PR DESCRIPTION
Fixes the issue where remote_syslog errors out when multiple init scripts are started in parallel and the network hasn't yet been initialised
