### PR TITLE
Added support for specifying application name in config file and command line

### DIFF
--- a/config_manager.go
+++ b/config_manager.go
@@ -304,16 +304,17 @@ func (cm *ConfigManager) Files() []LogFile {
 		switch v.Kind() {
 		case reflect.String:
 			logFiles = append(logFiles, LogFile{Tag: "", Path: v.String()})
-			break
 		case reflect.Map:
 			m := v.Interface().(map[interface{}]interface{})
 			tag := reflect.ValueOf(m["tag"])
 			path := reflect.ValueOf(m["path"])
 			if tag.Kind() == reflect.String && path.Kind() == reflect.String {
 				logFiles = append(logFiles, LogFile{Tag: tag.String(), Path: path.String()})
+				break
 			}
-			break
+			fallthrough
 		default:
+			log.Errorf("Cloud not parse log file configuration: %v", v)
 		}
 	}
 	return logFiles

--- a/config_manager.go
+++ b/config_manager.go
@@ -182,6 +182,8 @@ func (cm *ConfigManager) parseFlags() {
 		log := strings.Split(arg, ":")
 		if len(log) == 2 {
 			cm.FlagFiles = append(cm.FlagFiles, LogFile{Tag: log[0], Path: log[1]})
+		} else {
+			cm.FlagFiles = append(cm.FlagFiles, LogFile{Tag: "", Path: log[0]})
 		}
 	}
 }

--- a/config_manager.go
+++ b/config_manager.go
@@ -23,8 +23,8 @@ const (
 )
 
 type LogFile struct {
-	Path        string
-	Application string
+	Path string
+	Tag  string
 }
 
 type ConfigFile struct {
@@ -181,7 +181,7 @@ func (cm *ConfigManager) parseFlags() {
 	for _, arg := range pflag.Args() {
 		log := strings.Split(arg, ":")
 		if len(log) == 2 {
-			cm.FlagFiles = append(cm.FlagFiles, LogFile{Application: log[0], Path: log[1]})
+			cm.FlagFiles = append(cm.FlagFiles, LogFile{Tag: log[0], Path: log[1]})
 		}
 	}
 }

--- a/config_manager.go
+++ b/config_manager.go
@@ -28,7 +28,7 @@ type LogFile struct {
 }
 
 type ConfigFile struct {
-	Files       []LogFile
+	Files       []string
 	Destination struct {
 		Host     string `yaml:"host"`
 		Port     int    `yaml:"port"`
@@ -297,7 +297,16 @@ func (cm *ConfigManager) Poll() bool {
 }
 
 func (cm *ConfigManager) Files() []LogFile {
-	return append(cm.FlagFiles, cm.Config.Files...)
+	logFiles := cm.FlagFiles
+	for _, file := range cm.Config.Files {
+		log := strings.Split(file, ":")
+		if len(log) == 2 {
+			logFiles = append(logFiles, LogFile{Tag: log[0], Path: log[1]})
+		} else {
+			logFiles = append(logFiles, LogFile{Tag: "", Path: log[0]})
+		}
+	}
+	return logFiles
 }
 
 func (cm *ConfigManager) DebugLogFile() string {

--- a/config_manager.go
+++ b/config_manager.go
@@ -314,7 +314,7 @@ func (cm *ConfigManager) Files() []LogFile {
 			}
 			fallthrough
 		default:
-			log.Errorf("Cloud not parse log file configuration: %v", v)
+			log.Errorf("Could not parse log file configuration: %v", v)
 		}
 	}
 	return logFiles

--- a/config_manager.go
+++ b/config_manager.go
@@ -180,7 +180,7 @@ func (cm *ConfigManager) parseFlags() {
 	pflag.StringVar(&cm.Flags.LogLevels, "log", "<root>=INFO", "\"logging configuration <root>=INFO;first=TRACE\"")
 	pflag.Parse()
 	for _, arg := range pflag.Args() {
-		log := strings.Split(arg, ":")
+		log := strings.Split(arg, "=")
 		if len(log) == 2 {
 			cm.FlagFiles = append(cm.FlagFiles, LogFile{Tag: log[0], Path: log[1]})
 		} else {

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,6 +1,6 @@
 files:
   - path: locallog.txt
-    application: my_app
+    tag: my_app
 destination:
   host: logs.papertrailapp.com
   port: 514

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,5 +1,6 @@
 files:
-  - locallog.txt
+  - path: locallog.txt
+    application: my_app
 destination:
   host: logs.papertrailapp.com
   port: 514

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,6 +1,5 @@
 files:
-  - path: locallog.txt
-    tag: my_app
+  - locallog.txt
 destination:
   host: logs.papertrailapp.com
   port: 514

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -67,7 +67,7 @@ func globFiles(globs []LogFile, excludedFiles []*regexp.Regexp, excludePatterns 
 	log.Debugf("Evaluating file globs")
 	for _, glob := range globs {
 
-		tag := glob.Application
+		tag := glob.Tag
 		files, err := filepath.Glob(utils.ResolvePath(glob.Path))
 
 		if err != nil {

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -18,7 +17,7 @@ import (
 var log = loggo.GetLogger("")
 
 // Tails a single file
-func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, severity syslog.Priority, facility syslog.Priority, poll bool, tag string) {
 	defer wr.Remove(file)
 	wr.Add(file)
 	tailConfig := tail.Config{ReOpen: true, Follow: true, MustExist: true, Poll: poll, Location: &tail.SeekInfo{0, os.SEEK_END}}
@@ -37,7 +36,7 @@ func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logge
 				Facility: facility,
 				Time:     time.Now(),
 				Hostname: logger.ClientHostname,
-				Tag:      path.Base(file),
+				Tag:      tag,
 				Message:  line.Text,
 			}
 			log.Tracef("Forwarding: %s", line.Text)
@@ -52,7 +51,7 @@ func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logge
 
 // Tails files speficied in the globs and re-evaluates the globs
 // at the specified interval
-func tailFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, interval RefreshInterval, logger *syslog.Logger, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func tailFiles(globs []LogFile, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, interval RefreshInterval, logger *syslog.Logger, severity syslog.Priority, facility syslog.Priority, poll bool) {
 	wr := NewWorkerRegistry()
 	log.Debugf("Evaluating globs every %s", interval.Duration)
 	logMissingFiles := true
@@ -64,16 +63,17 @@ func tailFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns [
 }
 
 //
-func globFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, logMissingFiles bool, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func globFiles(globs []LogFile, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, logMissingFiles bool, severity syslog.Priority, facility syslog.Priority, poll bool) {
 	log.Debugf("Evaluating file globs")
 	for _, glob := range globs {
 
-		files, err := filepath.Glob(utils.ResolvePath(glob))
+		tag := glob.Application
+		files, err := filepath.Glob(utils.ResolvePath(glob.Path))
 
 		if err != nil {
-			log.Errorf("Failed to glob %s: %s", glob, err)
+			log.Errorf("Failed to glob %s: %s", glob.Path, err)
 		} else if files == nil && logMissingFiles {
-			log.Errorf("Cannot forward %s, it may not exist", glob)
+			log.Errorf("Cannot forward %s, it may not exist", glob.Path)
 		}
 
 		for _, file := range files {
@@ -84,7 +84,7 @@ func globFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns [
 				log.Debugf("Skipping %s because it is excluded by regular expression", file)
 			default:
 				log.Infof("Forwarding %s", file)
-				go tailOne(file, excludePatterns, logger, wr, severity, facility, poll)
+				go tailOne(file, excludePatterns, logger, wr, severity, facility, poll, tag)
 			}
 		}
 	}

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -27,6 +28,10 @@ func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logge
 	if err != nil {
 		log.Errorf("%s", err)
 		return
+	}
+
+	if tag == "" {
+		tag = path.Base(file)
 	}
 
 	for line := range t.Lines {


### PR DESCRIPTION
This commit makes it possible to specify application name in configuration file:
```yaml
files:
  - path: locallog.txt
    application: my_app
```
or in command line:
```bash
$ remote_syslog my_app:locallog.txt
```