### PR TITLE
LaunchDaemon: Use explicit path

### DIFF
--- a/examples/com.papertrailapp.remote_syslog.plist
+++ b/examples/com.papertrailapp.remote_syslog.plist
@@ -13,7 +13,7 @@
     <string>root</string>
     <key>ProgramArguments</key>
     <array>
-      <string>remote_syslog</string>
+      <string>/usr/local/bin/remote_syslog</string>
       <string>-D</string>
     </array>
   </dict>


### PR DESCRIPTION
When installing this to /Library/LaunchDaemons on Yosemite, the service fails on startup without this change. The most likely explanation is that /usr/local/bin is not in the path for launchd.

This path works with the install instructions in the readme.