### PR TITLE
Add option to sync from beginning of log file #83

### DIFF
--- a/config_manager.go
+++ b/config_manager.go
@@ -29,6 +29,7 @@ type ConfigFile struct {
 		Protocol string `yaml:"protocol"`
 	}
 	Hostname string `yaml:"hostname"`
+	Rewind   bool   `yaml:"rewind_before_tail"`
 	//SetYAML is only called on pointers
 	RefreshInterval *RefreshInterval `yaml:"new_file_check_interval"`
 	ExcludeFiles    *RegexCollection `yaml:"exclude_files"`

--- a/config_manager.go
+++ b/config_manager.go
@@ -358,5 +358,5 @@ func (cm *ConfigManager) ExcludePatterns() []*regexp.Regexp {
 }
 
 func (cm *ConfigManager) Rewind() bool {
-	return cm.Flags.Rewind
+	return cm.Flags.Rewind || cm.Config.Rewind
 }

--- a/config_manager.go
+++ b/config_manager.go
@@ -53,6 +53,7 @@ type ConfigManager struct {
 		Severity        string
 		Facility        string
 		Poll            bool
+		Rewind          bool
 	}
 }
 
@@ -171,6 +172,7 @@ func (cm *ConfigManager) parseFlags() {
 	_ = pflag.Bool("eventmachine-tail", false, "No action, provided for backwards compatibility")
 	pflag.StringVar(&cm.Flags.DebugLogFile, "debug-log-cfg", "", "the debug log file")
 	pflag.StringVar(&cm.Flags.LogLevels, "log", "<root>=INFO", "\"logging configuration <root>=INFO;first=TRACE\"")
+	pflag.BoolVar(&cm.Flags.Rewind, "rewind", false, "Rewind files before starting tail")
 	pflag.Parse()
 	cm.FlagFiles = pflag.Args()
 }
@@ -352,4 +354,8 @@ func (cm *ConfigManager) ExcludeFiles() []*regexp.Regexp {
 
 func (cm *ConfigManager) ExcludePatterns() []*regexp.Regexp {
 	return *cm.Config.ExcludePatterns
+}
+
+func (cm *ConfigManager) Rewind() bool {
+	return cm.Flags.Rewind
 }

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -18,10 +18,14 @@ import (
 var log = loggo.GetLogger("")
 
 // Tails a single file
-func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, severity syslog.Priority, facility syslog.Priority, poll bool, rewind bool) {
 	defer wr.Remove(file)
 	wr.Add(file)
-	tailConfig := tail.Config{ReOpen: true, Follow: true, MustExist: true, Poll: poll, Location: &tail.SeekInfo{0, os.SEEK_END}}
+	whence := os.SEEK_END
+	if rewind {
+		whence = os.SEEK_SET
+	}
+	tailConfig := tail.Config{ReOpen: true, Follow: true, MustExist: true, Poll: poll, Location: &tail.SeekInfo{0, whence}}
 
 	t, err := tail.TailFile(file, tailConfig)
 
@@ -52,19 +56,19 @@ func tailOne(file string, excludePatterns []*regexp.Regexp, logger *syslog.Logge
 
 // Tails files speficied in the globs and re-evaluates the globs
 // at the specified interval
-func tailFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, interval RefreshInterval, logger *syslog.Logger, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func tailFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, interval RefreshInterval, logger *syslog.Logger, severity syslog.Priority, facility syslog.Priority, poll bool, rewind bool) {
 	wr := NewWorkerRegistry()
 	log.Debugf("Evaluating globs every %s", interval.Duration)
 	logMissingFiles := true
 	for {
-		globFiles(globs, excludedFiles, excludePatterns, logger, &wr, logMissingFiles, severity, facility, poll)
+		globFiles(globs, excludedFiles, excludePatterns, logger, &wr, logMissingFiles, severity, facility, poll, rewind)
 		time.Sleep(interval.Duration)
 		logMissingFiles = false
 	}
 }
 
 //
-func globFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, logMissingFiles bool, severity syslog.Priority, facility syslog.Priority, poll bool) {
+func globFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns []*regexp.Regexp, logger *syslog.Logger, wr *WorkerRegistry, logMissingFiles bool, severity syslog.Priority, facility syslog.Priority, poll bool, rewind bool) {
 	log.Debugf("Evaluating file globs")
 	for _, glob := range globs {
 
@@ -84,7 +88,7 @@ func globFiles(globs []string, excludedFiles []*regexp.Regexp, excludePatterns [
 				log.Debugf("Skipping %s because it is excluded by regular expression", file)
 			default:
 				log.Infof("Forwarding %s", file)
-				go tailOne(file, excludePatterns, logger, wr, severity, facility, poll)
+				go tailOne(file, excludePatterns, logger, wr, severity, facility, poll, rewind)
 			}
 		}
 	}
@@ -119,7 +123,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	go tailFiles(cm.Files(), cm.ExcludeFiles(), cm.ExcludePatterns(), cm.RefreshInterval(), logger, cm.Severity(), cm.Facility(), cm.Poll())
+	go tailFiles(cm.Files(), cm.ExcludeFiles(), cm.ExcludePatterns(), cm.RefreshInterval(), logger, cm.Severity(), cm.Facility(), cm.Poll(), cm.Rewind())
 
 	for err = range logger.Errors {
 		log.Errorf("Syslog error: %v", err)


### PR DESCRIPTION
https://github.com/papertrail/remote_syslog2/issues/83

New command line and YAML parameter to specify whether the tail should begin at the end (default) or beginning of each file.  I would rather uniq my log statements than miss out on them entirely as can be the case during log rotation and remote_syslog's 10 second check for new files.