### PR TITLE
Added status() to return exit codes

### DIFF
--- a/packaging/linux/remote_syslog.initd
+++ b/packaging/linux/remote_syslog.initd
@@ -87,9 +87,13 @@ stop(){
 status(){
   if (is_running); then
     echo "Running"
+    RETVAL=0
   else
     echo "Not running"
+    RETVAL=3
   fi
+  
+  return $RETVAL
 }
 
 reload(){


### PR DESCRIPTION
status() always returned 0 which wouldn't trigger puppet to start it when stopped.