### PR TITLE
Enable cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ package: $(BUILD_PAIRS)
 build: depend clean test
 	@echo
 	@echo "\033[32mBuilding ----> \033[m"
-	$(GODEP) gox -os="$(X64_PLATFORMS)" -arch="amd64" -output "build/{{.OS}}/amd64/remote_syslog/remote_syslog"
-	$(GODEP) gox -os="$(X86_PLATFORMS)" -arch="386" -output "build/{{.OS}}/i386/remote_syslog/remote_syslog"
+	$(GODEP) gox -cgo -os="$(X64_PLATFORMS)" -arch="amd64" -output "build/{{.OS}}/amd64/remote_syslog/remote_syslog"
+	$(GODEP) gox -cgo -os="$(X86_PLATFORMS)" -arch="386" -output "build/{{.OS}}/i386/remote_syslog/remote_syslog"
 
 
 clean:


### PR DESCRIPTION
[A recent change in Gox](https://github.com/mitchellh/gox/commit/90c31d67ccff1b2054617fac93b7acb107e52b6b) disables cgo by default, which breaks the build on OS X. To fix that, pass in the `-cgo` switch.