### PR TITLE
Update `ExecStart` to use correct binary

### DIFF
--- a/examples/remote_syslog.systemd.service
+++ b/examples/remote_syslog.systemd.service
@@ -5,7 +5,7 @@ After=rsyslog.service
 
 [Service]
 ExecStartPre=/usr/bin/test -e /etc/log_files.yml
-ExecStart=/usr/local/bin/remote_syslog -D
+ExecStart=/usr/local/bin/remote_syslog2 -D
 Restart=always
 User=root
 Group=root


### PR DESCRIPTION
The `ExecStart` command was still set to use the `remote_syslog` binary,
rather than the newer `remote_syslog2` binary.