### PR TITLE
Move log_files.yml to subdir in etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,9 @@ $(BUILD_PAIRS): build
 
 	if [ "$(PLATFORM)" = "linux" ]; then\
 		mkdir -p pkg/tmp/etc/init.d;\
+		mkdir pkg/tmp/etc/remote_syslog;\
 		mkdir -p pkg/tmp/usr/local/bin;\
-		cp -f example_config.yml pkg/tmp/etc/log_files.yml;\
+		cp -f example_config.yml pkg/tmp/etc/remote_syslog/log_files.yml;\
 		cp -f packaging/linux/remote_syslog.initd pkg/tmp/etc/init.d/remote_syslog;\
 		cp -f build/$@/remote_syslog/remote_syslog pkg/tmp/usr/local/bin;\
 		(cd pkg && \
@@ -111,8 +112,8 @@ $(BUILD_PAIRS): build
 		  --url $(PACKAGE_URL) \
 		  --before-remove ../packaging/linux/deb/prerm \
 		  --after-install ../packaging/linux/deb/postinst \
-		  --config-files etc/log_files.yml \
-		  --config-files etc/init.d/remote_syslog usr/local/bin/remote_syslog etc/log_files.yml etc/init.d/remote_syslog && \
+		  --config-files etc/remote_syslog/log_files.yml etc/init.d/remote_syslog \
+			usr/local/bin/remote_syslog etc/init.d/remote_syslog etc/remote_syslog/log_files.yml && \
 		fpm \
 		  -s dir \
 		  -C tmp \
@@ -127,9 +128,9 @@ $(BUILD_PAIRS): build
 		  --url $(PACKAGE_URL) \
 		  --before-remove ../packaging/linux/rpm/preun \
 		  --after-install ../packaging/linux/rpm/post \
-		  --config-files etc/log_files.yml \
+		  --config-files etc/remote_syslog/log_files.yml \
 		  --config-files etc/init.d/remote_syslog \
-		  --rpm-os linux usr/local/bin/remote_syslog etc/log_files.yml etc/init.d/remote_syslog );\
+		  --rpm-os linux usr/local/bin/remote_syslog etc/remote_syslog/log_files.yml etc/init.d/remote_syslog );\
 		rm -R -f pkg/tmp;\
 	fi
 

--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ Untar the package, copy the "remote_syslog" executable into your $PATH,
 and then customize the included example_config.yml with the log file paths
 to read and the host/port to log to.
 
-Optionally, move and rename the configuration file to `/etc/log_files.yml` so
+Optionally, move and rename the configuration file to `/etc/remote_syslog/log_files.yml` so
 that remote_syslog picks it up automatically. For example:
 
     sudo cp ./remote_syslog /usr/local/bin
-    sudo cp example_config.yml /etc/log_files.yml
-    sudo vi /etc/log_files.yml
+    sudo mkdir /etc/remote_syslog
+    sudo cp example_config.yml /etc/remote_syslog/log_files.yml
+    sudo vi /etc/remote_syslog/log_files.yml
 
 Configuration directives can also be specified as command-line arguments (below).
 
 ## Usage
 
     Usage of remote_syslog2:
-      -c, --configfile="/etc/log_files.yml": Path to config
+      -c, --configfile="/etc/remote_syslog/log_files.yml": Path to config
           --debug-log-cfg="": the debug log file
       -d, --dest-host="": Destination syslog hostname or IP
       -p, --dest-port=514: Destination syslog port
@@ -82,7 +83,7 @@ and send to port `logs.papertrailapp.com:12345`:
 
     $ remote_syslog -c example_config.yml -p 12345 --pid-file=/tmp/remote_syslog.pid /var/log/mysqld.log
 
-Stay attached to the terminal, look for and use `/etc/log_files.yml` if it
+Stay attached to the terminal, look for and use `/etc/remote_syslog/log_files.yml` if it
 exists, and send with facility local0 to `a.example.com:514`:
 
     $ remote_syslog -D -d a.example.com -f local0 /var/log/mysqld.log
@@ -121,11 +122,11 @@ or add `protocol: tls` to your configuration file.
 
 ## Configuration
 
-By default, remote_syslog looks for a configuration in `/etc/log_files.yml`.
+By default, remote_syslog looks for a configuration in `/etc/remote_syslog/log_files.yml`.
 
 The archive comes with a [sample config](https://github.com/papertrail/remote_syslog2/blob/master/example_config.yml). Optionally:
 
-    $ cp example_config.yml.example /etc/log_files.yml
+    $ cp example_config.yml.example /etc/remote_syslog/log_files.yml
 
 `log_files.yml` has filenames to log from (as an array) and hostname and port
 to log to (as a hash). Wildcards are supported using * and standard shell

--- a/config_manager.go
+++ b/config_manager.go
@@ -22,7 +22,7 @@ var Version string
 
 const (
 	MinimumRefreshInterval = (time.Duration(10) * time.Second)
-	DefaultConfigFile      = "/etc/log_files.yml"
+	DefaultConfigFile      = "/etc/remote_syslog/log_files.yml"
 )
 
 type LogFile struct {

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ This is an example Mac OS X plist file.  This file should be placed at `/Library
 
 ## log_files.yml.example
 
-This is a simple configuration file example.  Use it as a template for your configuration.  This file should be placed at `/etc/log_files.yml`.
+This is a simple configuration file example.  Use it as a template for your configuration.  This file should be placed at `/etc/remote_syslog/log_files.yml`.
 
 ## log_files.yml.example.advanced
 

--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -9,7 +9,7 @@ sources:
   /home/ec2-user: https://github.com/papertrail/remote_syslog2/releases/download/<VERSION>/remote_syslog_linux_amd64.tar.gz
 
 files:
-  "/etc/log_files.yml":
+  "/etc/remote_syslog/log_files.yml":
     mode: "00644"
     owner: root
     group: root
@@ -56,7 +56,7 @@ files:
       . /etc/sysconfig/network
        
       prog="/usr/local/bin/remote_syslog"   
-      config="/etc/log_files.yml"
+      config="/etc/remote_syslog/log_files.yml"
       pid_dir="/var/run"
  
       EXTRAOPTIONS=""

--- a/examples/remote_syslog.init.d
+++ b/examples/remote_syslog.init.d
@@ -20,7 +20,7 @@
 # processname: remote_syslog
 
 prog="remote_syslog"
-config="/etc/log_files.yml"
+config="/etc/remote_syslog/log_files.yml"
 pid_dir="/var/run"
 
 EXTRAOPTIONS=""

--- a/examples/remote_syslog.systemd.service
+++ b/examples/remote_syslog.systemd.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/papertrail/remote_syslog2
 After=rsyslog.service
 
 [Service]
-ExecStartPre=/usr/bin/test -e /etc/log_files.yml
+ExecStartPre=/usr/bin/test -e /etc/remote_syslog/log_files.yml
 ExecStart=/usr/local/bin/remote_syslog -D
 Restart=always
 User=root

--- a/examples/remote_syslog.upstart.conf
+++ b/examples/remote_syslog.upstart.conf
@@ -4,6 +4,6 @@ stop on runlevel [!2345]
 
 respawn
 
-pre-start exec /usr/bin/test -e /etc/log_files.yml
+pre-start exec /usr/bin/test -e /etc/remote_syslog/log_files.yml
 
 exec remote_syslog -D

--- a/packaging/Makefile.packaging
+++ b/packaging/Makefile.packaging
@@ -1,4 +1,4 @@
-PACKAGE_VERSION := 0.17
+PACKAGE_VERSION := 0.17.innerteapot1
 PACKAGE_NAME := remote_syslog2
 PACKAGE_VENDOR := "Papertrail Inc."
 PACKAGE_LICENSE := "MIT License"

--- a/packaging/linux/remote_syslog.initd
+++ b/packaging/linux/remote_syslog.initd
@@ -20,7 +20,7 @@
 # processname: remote_syslog
 
 prog="remote_syslog"
-config="/etc/log_files.yml"
+config="/etc/remote_syslog/log_files.yml"
 pid_dir="/var/run"
 
 EXTRAOPTIONS=""


### PR DESCRIPTION
Hi there,

I've been experimenting with using papertrail on the stillstream.fm servers and found the deb package here. It made installation a breeze! Thank you :)

Myself I like to have config files in etc named so I don't forget what they are so I've set up this fork to move log_files.yml int0 /etc/remote_syslog. I hope you'll consider adding these changes into the main branch.

In my testing I found fpm a little temperamental. Adding the config files twice seemed to satisfy it somehow.

Thanks, Joel

