### PR TITLE
Continue monitoring when logging directories are recreated

### DIFF
--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -59,7 +59,7 @@ files:
       config="/etc/log_files.yml"
       pid_dir="/var/run"
  
-      EXTRAOPTIONS=""
+      EXTRAOPTIONS="--poll=true"
  
       pid_file="$pid_dir/remote_syslog.pid"
  


### PR DESCRIPTION
There's a bug in r_s2's inotify lib where it doesn't notice when a logging directory is recreated. Work around that for now by polling for changes.