### PR TITLE
Configure logger sender name

### DIFF
--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -17,11 +17,28 @@ files:
     content: |
       files:
         - <YOUR-TRACKED-FILES>
-      hostname: <YOUR-APP-NAME>
+      hostname: ##WILL_BE_REPLACED##
       destination:
         host: <YOUR-LOG-DESTINATION>
         port: <YOUR-PORT-NUMBER>
         protocol: tls
+        
+  "/tmp/set-logger-hostname.sh":
+    mode: "00555"
+    owner: root
+    group: root
+    encoding: plain
+    content: |
+      #!/bin/bash
+      logger_config="/etc/log_files.yml"
+      appname=`{ "Ref" : "AWSEBEnvironmentName" }`
+      instid=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
+      myhostname=${appname}_${instid}
+  
+      if [ -f $logger_config ]; then
+        # Sub the hostname
+        sed "s/hostname:.*/hostname: $myhostname/" -i $logger_config       
+      fi
  
   "/etc/init.d/remote_syslog":
     mode: "00555"
@@ -156,17 +173,20 @@ files:
  
       exit $RETVAL
  
-commands:
+container_commands:
   00_stop_service:
     command: "/sbin/service remote_syslog stop"
     ignoreErrors: true
+
+  01_set_logger_hostname:
+    command: ". /tmp/set-logger-hostname.sh"
     
-  01_install_remote_syslog_binary:
+  02_install_remote_syslog_binary:
     command: "cp /home/ec2-user/remote_syslog/remote_syslog /usr/local/bin"
   
-  02_enable_service:
+  03_enable_service:
     command: "/sbin/chkconfig remote_syslog on"
  
-  03_start_service:
+  04_start_service:
     command: "/sbin/service remote_syslog restart"
     ignoreErrors: true


### PR DESCRIPTION
Set the logger's sender name to the Beanstalk environment name and instance ID. For example: `myenv_i-XXXXXXbd`