### PR TITLE
Close connection on error

### DIFF
--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -162,6 +162,8 @@ func (l *Logger) writePacket(p Packet) {
 		if err == nil {
 			return
 		} else {
+			// We had an error -- we need to close the connection and try again
+			l.conn.netConn.Close()
 			l.handleError(err)
 			time.Sleep(10 * time.Second)
 		}


### PR DESCRIPTION
If there is an error or timeout while sending log messages, close the connection to ensure it is reopened again.

I believe this will fix many of the issues we've seen with logs never being sent.