### PR TITLE
Better elastic beanstalk sample

### DIFF
--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -1,7 +1,7 @@
 # See http://help.papertrailapp.com/kb/hosting-services/aws-elastic-beanstalk/
 # Usage:
-# - replace <VERSION> with the version of remote_syslog2 you want to use. Example: .../download/v0.14/remote_syslog_linux_amd64.tar.gz
-# - replace <YOUR-TRACKED-FILES> with the files you want to monitor for new log lines. Example:  - /var/log/httpd/access_log
+# - replace <VERSION> with the version of remote_syslog2 you want to use. Example: .../download/v0.17/remote_syslog_linux_amd64.tar.gz
+# - replace <YOUR-TRACKED-FILES> with the files you want to monitor for new log lines. Example:  - /var/log/tomcat*/catalina.out
 # - replace <YOUR-LOG-DESTINATION> and <YOUR-PORT-NUMBER> with the values shown under log destinations: https://papertrailapp.com/account/destinations
 
 sources:
@@ -15,7 +15,8 @@ files:
     encoding: plain
     content: |
       files:
-        - <YOUR-TRACKED-FILES>
+        - path: <YOUR-TRACKED-FILES>
+          tag: ##WILL_BE_REPLACED##
       hostname: ##WILL_BE_REPLACED##
       destination:
         host: <YOUR-LOG-DESTINATION>
@@ -32,11 +33,12 @@ files:
       logger_config="/etc/log_files.yml"
       appname=`{ "Ref" : "AWSEBEnvironmentName" }`
       instid=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
-      myhostname=${appname}_${instid}
   
       if [ -f $logger_config ]; then
+        # Sub the tag
+        sed "s/tag:.*/tag: $instid/" -i $logger_config
         # Sub the hostname
-        sed "s/hostname:.*/hostname: $myhostname/" -i $logger_config       
+        sed "s/hostname:.*/hostname: $appname/" -i $logger_config
       fi
  
   "/etc/init.d/remote_syslog":


### PR DESCRIPTION
Aggregate multiple instances log files under the same environment name. Each one is identified with its instance id. This way you can follow all the logs for a given environment in one place.
