### PR TITLE
Prevent loss of logs due to timeouts

### DIFF
--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -61,8 +61,8 @@ func dial(network, raddr string, rootCAs *x509.CertPool, connectTimeout time.Dur
 			config = &tls.Config{RootCAs: rootCAs}
 		}
 		dialer := &net.Dialer{
-			Timeout: connectTimeout,
-			KeepAlive:time.Second * 60 * 3, // 3 minutes
+			Timeout:   connectTimeout,
+			KeepAlive: time.Second * 60 * 3, // 3 minutes
 		}
 		netConn, err = tls.DialWithDialer(dialer, "tcp", raddr, config)
 	case "udp", "tcp":

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -62,6 +62,7 @@ func dial(network, raddr string, rootCAs *x509.CertPool, connectTimeout time.Dur
 		}
 		dialer := &net.Dialer{
 			Timeout: connectTimeout,
+			KeepAlive:time.Second * 60 * 3, // 3 minutes
 		}
 		netConn, err = tls.DialWithDialer(dialer, "tcp", raddr, config)
 	case "udp", "tcp":


### PR DESCRIPTION
Timeouts occuring due to inactivity cause a loss of logs (a broken pipe occurs on the next request, unfortunately theres no notice for the current request, and its just lost). 

Adding the keep alive for 3 minutes (from what we've seen) keeps the connection alive (or reconnects) if it fails.  In our tests this prevents the loss of log entries (and is a relatively small change).