### PR TITLE
Tail new files from beginning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 /build/
 /pkg/
 remote_syslog
+tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6.2
+  - tip
 install:
   - export PATH=$HOME/gopath/bin:$PATH
   - export GO15VENDOREXPERIMENT=1

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,13 @@ clean:
 	@echo "\033[32mCleaning Build ----> \033[m"
 	$(RM) -rf pkg/*
 	$(RM) -rf build/*
+	$(RM) -rf tmp/*
 
 
 test:
 	@echo
 	@echo "\033[32mTesting ----> \033[m"
-	go test ./...
+	go test -v -race ./...
 
 
 depend:

--- a/config.go
+++ b/config.go
@@ -127,6 +127,7 @@ func init() {
 	config.AutomaticEnv()
 }
 
+// Read in configuration from environment, flags, and specified or default config file.
 func NewConfigFromEnv() (*Config, error) {
 	pflag.Parse()
 

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -1,9 +1,47 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
 	"regexp"
 	"testing"
+	"time"
+
+	"github.com/papertrail/remote_syslog2/syslog"
+	"github.com/stretchr/testify/assert"
 )
+
+const (
+	tmpdir     = "./tmp"
+	listenHost = "localhost"
+	listenPort = 8999
+)
+
+var (
+	listener *net.UDPConn
+)
+
+func init() {
+	resAddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", listenHost, listenPort))
+	if err != nil {
+		panic(err)
+	}
+
+	listener, err = net.ListenUDP("udp", resAddr)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// main testing function to clean up after running
+func TestMain(m *testing.M) {
+	os.Mkdir(tmpdir, 0755)
+	rs := m.Run()
+	os.RemoveAll(tmpdir)
+	os.Exit(rs)
+}
 
 func TestFilters(t *testing.T) {
 	expressions := []*regexp.Regexp{}
@@ -16,5 +54,103 @@ func TestFilters(t *testing.T) {
 	message = "0000"
 	if !matchExps(message, expressions) {
 		t.Errorf("Expected \"%s\" to match \"%s\"", message, expressions[0])
+	}
+}
+
+func TestNewFileSeek(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewServer(testConfig())
+	go s.Start()
+	defer s.Close()
+
+	// just a quick rest to get the server started
+	time.Sleep(1 * time.Second)
+
+	for _, msg := range []string{
+		"welcome to the jungle",
+		"we got alerts and logs",
+		"we got everything you want",
+		"as long as it's alerts and logs",
+	} {
+		file := tmpLogFile()
+		defer file.Close()
+
+		writeLog(file, msg)
+
+		packet := readPacket()
+		assert.Equal(msg, packet.Message)
+	}
+}
+
+// write to test log file
+func writeLog(file *os.File, msg string) {
+	w := bufio.NewWriterSize(file, 1024*32)
+
+	if _, err := w.WriteString(msg + "\n"); err != nil {
+		panic(err)
+	}
+
+	w.Flush()
+}
+
+// creates a log file that matches our pattern (tmp/*.log)
+func tmpLogFile() *os.File {
+	file, err := os.Create(fmt.Sprintf("tmp/%d.log", time.Now().UnixNano()))
+	if err != nil {
+		panic(err)
+	}
+
+	return file
+}
+
+func readPacket() syslog.Packet {
+	listener.SetReadDeadline(time.Now().Add(1200 * time.Millisecond))
+	reader := bufio.NewReaderSize(listener, 1024*32)
+
+	line, prefix, err := reader.ReadLine()
+	if prefix {
+		panic("reader buffer too small")
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	packet, err := syslog.Parse(string(line))
+	if err != nil {
+		panic(err)
+	}
+
+	return packet
+}
+
+func testConfig() *Config {
+	severity, _ := syslog.Severity("info")
+	facility, _ := syslog.Facility("user")
+
+	return &Config{
+		ConnectTimeout:       10 * time.Second,
+		WriteTimeout:         10 * time.Second,
+		NewFileCheckInterval: 1 * time.Second,
+		LogLevels:            "<root>=INFO",
+		TcpMaxLineLength:     99990,
+		NoDetach:             true,
+		Hostname:             "testhost",
+		Severity:             severity,
+		Facility:             facility,
+		Destination: struct {
+			Host     string
+			Port     int
+			Protocol string
+		}{
+			Host:     listenHost,
+			Port:     listenPort,
+			Protocol: "udp",
+		},
+		Files: []LogFile{
+			{
+				Path: "tmp/*.log",
+			},
+		},
 	}
 }

--- a/syslog/packet.go
+++ b/syslog/packet.go
@@ -44,3 +44,35 @@ func (p Packet) Generate(max_size int) string {
 		}
 	}
 }
+
+// A convenience function for testing
+func Parse(line string) (Packet, error) {
+	var (
+		packet   Packet
+		priority int
+		ts       string
+		hostname string
+		tag      string
+	)
+
+	splitLine := strings.Split(line, " - - - ")
+	if len(splitLine) != 2 {
+		return packet, fmt.Errorf("couldn't parse %s", line)
+	}
+
+	fmt.Sscanf(splitLine[0], "<%d>1 %s %s %s", &priority, &ts, &hostname, &tag)
+
+	t, err := time.Parse(rfc5424time, ts)
+	if err != nil {
+		return packet, err
+	}
+
+	return Packet{
+		Severity: Priority(priority & 7),
+		Facility: Priority(priority >> 3),
+		Hostname: hostname,
+		Tag:      tag,
+		Time:     t,
+		Message:  splitLine[1],
+	}, nil
+}

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const clienthost = "clienthost"
@@ -117,17 +119,30 @@ func handle(conn io.ReadCloser, messages chan string) {
 func generatePackets() []Packet {
 	packets := make([]Packet, 10)
 	for i := range packets {
-		t, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z07:00")
+		t, _ := time.Parse(time.RFC3339, "2016-10-05T18:30:00Z07:00")
 		packets[i] = Packet{
 			Severity: SevInfo,
 			Facility: LogLocal1,
-			Time:     t,
+			Time:     t.UTC(),
 			Hostname: clienthost,
 			Tag:      "test",
 			Message:  fmt.Sprintf("message %d", i),
 		}
 	}
 	return packets
+}
+
+func TestParse(t *testing.T) {
+	packets := generatePackets()
+	for _, p := range packets {
+		line := p.Generate(0)
+		parsed, err := Parse(line)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.EqualValues(t, p, parsed)
+	}
 }
 
 func TestSyslog(t *testing.T) {


### PR DESCRIPTION
The primary purpose of this PR is to seek to the beginning of new files that appear after the rs2 process has started for globbed file configurations, e.g. `/var/log/*.log`. Fixes #83.

This also adds more testing to validate the message lifecycle from log file -> syslog endpoint.
