### PR TITLE
Regression: continue to connect if initial attempt fails

### DIFF
--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -65,10 +65,6 @@ func (s *Server) Start() error {
 	)
 	if err != nil {
 		log.Errorf("Cannot connect to server: %v", err)
-		// If the first dial fails, the connection will stay uninitialized (nil)
-		// and all subsequent attempts to reconnect will also fail.
-		// Instead of continuing, bail out at this error
-		return err
 	}
 
 	go s.tailFiles()
@@ -232,8 +228,5 @@ func main() {
 	utils.AddSignalHandlers()
 
 	s := NewServer(c)
-	if err = s.Start(); err != nil {
-		log.Criticalf("Failed to start server: %v", err)
-		os.Exit(255)
-	}
+	s.Start()
 }

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -126,7 +126,7 @@ func (s *Server) tailOne(file, tag string, whence int) {
 			}
 
 			if !matchExps(line.Text, s.config.ExcludePatterns) {
-				err := s.logger.Write(syslog.Packet{
+				s.logger.Write(syslog.Packet{
 					Severity: s.config.Severity,
 					Facility: s.config.Facility,
 					Time:     time.Now(),
@@ -134,11 +134,6 @@ func (s *Server) tailOne(file, tag string, whence int) {
 					Tag:      tag,
 					Message:  line.Text,
 				})
-
-				if err != nil {
-					log.Errorf("%s", err)
-					return
-				}
 
 				log.Tracef("Forwarding line: %s", line.Text)
 

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -64,7 +64,7 @@ func (s *Server) Start() error {
 		s.config.TcpMaxLineLength,
 	)
 	if err != nil {
-		log.Errorf("Cannot connect to server: %v", err)
+		log.Errorf("Initial connection to server failed: %v - connection will be retried", err)
 	}
 
 	go s.tailFiles()
@@ -223,5 +223,8 @@ func main() {
 	utils.AddSignalHandlers()
 
 	s := NewServer(c)
-	s.Start()
+	if err = s.Start(); err != nil {
+		log.Criticalf("Failed to start server: %v", err)
+		os.Exit(255)
+	}
 }

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -138,7 +138,7 @@ func (l *Logger) Close() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.conn != nil {
+	if !l.stopped {
 		l.stopped = true
 		l.stopChan <- struct{}{}
 


### PR DESCRIPTION
Reverts papertrail/remote_syslog2#175
@a-palchikov it looks like I merged your PR too soon, sorry about that, see the details below: 

Remote syslog should continue re-connection on startup, even if the initial connection attempt fails - as seen in #103.

This behavior was broken in #174 in that attempts to write to the syslog client would error if the remote was not connected. The behavior should now be to continue running and attempting to connect.
