### PR TITLE
Allow operation with no config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	config  *viper.Viper
+	flags   *pflag.FlagSet
 	Version string
 )
 
@@ -63,6 +64,12 @@ type LogFile struct {
 }
 
 func init() {
+	initConfigAndFlags()
+}
+
+func initConfigAndFlags() {
+	flags = pflag.NewFlagSet(envPrefix, pflag.ExitOnError)
+
 	config = viper.New()
 	config.SetEnvPrefix(envPrefix)
 
@@ -74,55 +81,55 @@ func init() {
 	config.SetDefault("write_timeout", 30*time.Second)
 
 	// set available commandline flags here:
-	pflag.StringP("configfile", "c", defaultConfigFile, "Path to config")
-	config.BindPFlag("config_file", pflag.Lookup("configfile"))
+	flags.StringP("configfile", "c", defaultConfigFile, "Path to config")
+	config.BindPFlag("config_file", flags.Lookup("configfile"))
 
-	pflag.StringP("dest-host", "d", "", "Destination syslog hostname or IP")
-	config.BindPFlag("destination.host", pflag.Lookup("dest-host"))
+	flags.StringP("dest-host", "d", "", "Destination syslog hostname or IP")
+	config.BindPFlag("destination.host", flags.Lookup("dest-host"))
 
-	pflag.IntP("dest-port", "p", 514, "Destination syslog port")
-	config.BindPFlag("destination.port", pflag.Lookup("dest-port"))
+	flags.IntP("dest-port", "p", 514, "Destination syslog port")
+	config.BindPFlag("destination.port", flags.Lookup("dest-port"))
 
-	pflag.StringP("facility", "f", "user", "Facility")
-	config.BindPFlag("facility", pflag.Lookup("facility"))
+	flags.StringP("facility", "f", "user", "Facility")
+	config.BindPFlag("facility", flags.Lookup("facility"))
 
 	hostname, _ := os.Hostname()
-	pflag.String("hostname", hostname, "Local hostname to send from")
-	config.BindPFlag("hostname", pflag.Lookup("hostname"))
+	flags.String("hostname", hostname, "Local hostname to send from")
+	config.BindPFlag("hostname", flags.Lookup("hostname"))
 
-	pflag.String("pid-file", "", "Location of the PID file")
-	config.BindPFlag("pid_file", pflag.Lookup("pid-file"))
+	flags.String("pid-file", "", "Location of the PID file")
+	config.BindPFlag("pid_file", flags.Lookup("pid-file"))
 
-	pflag.StringP("severity", "s", "notice", "Severity")
-	config.BindPFlag("severity", pflag.Lookup("severity"))
+	flags.StringP("severity", "s", "notice", "Severity")
+	config.BindPFlag("severity", flags.Lookup("severity"))
 
-	pflag.Bool("tcp", false, "Connect via TCP (no TLS)")
-	config.BindPFlag("tcp", pflag.Lookup("tcp"))
+	flags.Bool("tcp", false, "Connect via TCP (no TLS)")
+	config.BindPFlag("tcp", flags.Lookup("tcp"))
 
-	pflag.Bool("tls", false, "Connect via TCP with TLS")
-	config.BindPFlag("tls", pflag.Lookup("tls"))
+	flags.Bool("tls", false, "Connect via TCP with TLS")
+	config.BindPFlag("tls", flags.Lookup("tls"))
 
-	pflag.Bool("poll", false, "Detect changes by polling instead of inotify")
-	config.BindPFlag("poll", pflag.Lookup("poll"))
+	flags.Bool("poll", false, "Detect changes by polling instead of inotify")
+	config.BindPFlag("poll", flags.Lookup("poll"))
 
-	pflag.Int("new-file-check-interval", 10, "How often to check for new files (seconds)")
-	config.BindPFlag("new_file_check_interval", pflag.Lookup("new-file-check-interval"))
+	flags.Int("new-file-check-interval", 10, "How often to check for new files (seconds)")
+	config.BindPFlag("new_file_check_interval", flags.Lookup("new-file-check-interval"))
 
-	pflag.String("debug-log-cfg", "", "The debug log file; overridden by -D/--no-detach")
-	config.BindPFlag("debug_log_file", pflag.Lookup("debug-log-cfg"))
+	flags.String("debug-log-cfg", "", "The debug log file; overridden by -D/--no-detach")
+	config.BindPFlag("debug_log_file", flags.Lookup("debug-log-cfg"))
 
-	pflag.String("log", "<root>=INFO", "Set loggo config, like: --log=\"<root>=DEBUG\"")
-	config.BindPFlag("log_levels", pflag.Lookup("log"))
+	flags.String("log", "<root>=INFO", "Set loggo config, like: --log=\"<root>=DEBUG\"")
+	config.BindPFlag("log_levels", flags.Lookup("log"))
 
 	// only present this flag to systems that can daemonize
 	if utils.CanDaemonize {
-		pflag.BoolP("no-detach", "D", false, "Don't daemonize and detach from the terminal; overrides --debug-log-cfg")
-		config.BindPFlag("no_detach", pflag.Lookup("no-detach"))
+		flags.BoolP("no-detach", "D", false, "Don't daemonize and detach from the terminal; overrides --debug-log-cfg")
+		config.BindPFlag("no_detach", flags.Lookup("no-detach"))
 	}
 
 	// deprecated flags
-	pflag.Bool("no-eventmachine-tail", false, "No action, provided for backwards compatibility")
-	pflag.Bool("eventmachine-tail", false, "No action, provided for backwards compatibility")
+	flags.Bool("no-eventmachine-tail", false, "No action, provided for backwards compatibility")
+	flags.Bool("eventmachine-tail", false, "No action, provided for backwards compatibility")
 
 	// bind env vars to config automatically
 	config.AutomaticEnv()
@@ -130,7 +137,7 @@ func init() {
 
 // Read in configuration from environment, flags, and specified or default config file.
 func NewConfigFromEnv() (*Config, error) {
-	pflag.Parse()
+	flags.Parse(os.Args[1:])
 
 	c := &Config{}
 
@@ -184,7 +191,7 @@ func NewConfigFromEnv() (*Config, error) {
 	}
 
 	// collect any extra args passed on the command line and add them to our file list
-	for _, file := range pflag.Args() {
+	for _, file := range flags.Args() {
 		files, err := decodeLogFiles([]interface{}{file})
 		if err != nil {
 			return nil, err

--- a/config_test.go
+++ b/config_test.go
@@ -7,16 +7,16 @@ import (
 
 	"github.com/papertrail/remote_syslog2/papertrail"
 	"github.com/papertrail/remote_syslog2/syslog"
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRawConfig(t *testing.T) {
 	assert := assert.New(t)
+	initConfigAndFlags()
 
 	// pretend like some things were passed on the command line
-	pflag.Set("configfile", "test/config.yaml")
-	pflag.Set("tls", "true")
+	flags.Set("configfile", "test/config.yaml")
+	flags.Set("tls", "true")
 
 	c, err := NewConfigFromEnv()
 	if err != nil {
@@ -67,4 +67,22 @@ func TestRawConfig(t *testing.T) {
 	assert.NotEqual(c.Hostname, "")
 	assert.Equal(c.Poll, false)
 	assert.Equal(c.RootCAs, papertrail.RootCA())
+}
+
+func TestNoConfigFile(t *testing.T) {
+	assert := assert.New(t)
+	initConfigAndFlags()
+
+	flags.Set("dest-host", "localhost")
+	flags.Set("dest-port", "999")
+
+	c, err := NewConfigFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NoError(c.Validate())
+	assert.Equal("localhost", c.Destination.Host)
+	assert.Equal(999, c.Destination.Port)
+	assert.Equal("udp", c.Destination.Protocol)
 }


### PR DESCRIPTION
Fixes a bug introduced in #170. This allows the use of `remote_syslog` with no config file.