### PR TITLE
Fix race condition leading to duplicate tailing

### DIFF
--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -123,9 +123,6 @@ func (s *Server) tailOne(file, tag string, whence int) {
 			if s.closing() {
 				return
 			}
-			if line == nil {
-				continue
-			}
 
 			if !matchExps(line.Text, s.config.ExcludePatterns) {
 				s.logger.Write(syslog.Packet{

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -99,7 +99,6 @@ func (s *Server) closing() bool {
 // Tails a single file
 func (s *Server) tailOne(file, tag string, whence int) {
 	defer s.registry.Remove(file)
-	s.registry.Add(file)
 
 	t, err := tail.TailFile(file, tail.Config{
 		ReOpen:    true,
@@ -123,6 +122,9 @@ func (s *Server) tailOne(file, tag string, whence int) {
 		case line := <-t.Lines:
 			if s.closing() {
 				return
+			}
+			if line == nil {
+				continue
 			}
 
 			if !matchExps(line.Text, s.config.ExcludePatterns) {
@@ -196,6 +198,7 @@ func (s *Server) globFiles(firstPass bool) {
 					whence = io.SeekEnd
 				}
 
+				s.registry.Add(file)
 				go s.tailOne(file, tag, whence)
 			}
 		}

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -26,7 +26,7 @@ var (
 type Server struct {
 	config   *Config
 	logger   *syslog.Logger
-	registry *WorkerRegistry
+	registry WorkerRegistry
 	stopChan chan struct{}
 	stopped  bool
 	mu       sync.RWMutex
@@ -35,7 +35,7 @@ type Server struct {
 func NewServer(config *Config) *Server {
 	return &Server{
 		config:   config,
-		registry: NewWorkerRegistry(),
+		registry: NewInMemoryRegistry(),
 		stopChan: make(chan struct{}),
 	}
 }

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -91,14 +91,18 @@ func TestNewFileSeek(t *testing.T) {
 func TestGlobCollisions(t *testing.T) {
 	assert := assert.New(t)
 
-	// Add many colliding globs
+	// Make sure we're running on a clean directory
+	os.RemoveAll(tmpdir)
+	os.Mkdir(tmpdir, 0755)
+
+	// Add colliding globs
 	config := testConfig()
 	config.Files = append(config.Files, LogFile{
 		Path: "tmp/*.log",
 	})
-	config.LogLevels = "<root>=TRACE"
 
 	// Setup a test logger so we can observe the server's behavior
+	config.LogLevels = "<root>=TRACE"
 	_, _, err := loggo.RemoveWriter("default")
 	assert.NoError(err)
 	sink := new(testWriter)

--- a/syslog/syslog.go
+++ b/syslog/syslog.go
@@ -98,7 +98,7 @@ type Logger struct {
 	connectTimeout   time.Duration
 	writeTimeout     time.Duration
 	tcpMaxLineLength int
-	mu               sync.Mutex
+	mu               sync.RWMutex
 	stopChan         chan struct{}
 	stopped          bool
 }
@@ -127,6 +127,9 @@ func Dial(clientHostname, network, raddr string, rootCAs *x509.CertPool, connect
 }
 
 func (l *Logger) Write(packet Packet) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
 	if l.stopped {
 		return
 	}


### PR DESCRIPTION
### Expected

If a file is matched by two (or more) globs, `remote_syslog2` matches the first glob in the list, and ignores subsequent matches
### Actual

Sometimes, due to a race condition, a log file ends up being tailed twice. I encountered this today, we're using 0.18. Here's a [trace](https://gist.github.com/Bowbaq/be3005ec2ccc1053204f8ae9bdd0f761). Notice that the some files are forwarded twice (line 7 and 29 for example).
### Fix

Adding the file to the registry synchronously seems to fix the problem. I've added a test (not necessarily a fan of hijacking the logs but ...). Running that test on the current `master` fails most of the time. 
