### PR TITLE
Take into account watched files that are truncated and filled with NUL bytes by the OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ concern as to which method is used. If a log file is moved or renamed,
 and a new file is created (at a new inode), `remote_syslog` will follow that
 new file at the new inode (assuming it has the same absolute path name). If
 a file is copied then truncated, `remote_syslog` will seek to the beginning of
-the truncated file continue to read it.
+the truncated file and continue to read it.
 
 #### Log rotation edge cases to be aware of
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ than the current set of matches). This is not necessary for globs defined in
 the config file.
 
 
-### Log rotation
+### Log rotation and the behavior of remote_syslog
 
 External log rotation scripts often move or remove an existing log file
 and replace it with a new one (at a new inode). The Linux standard script
@@ -194,11 +194,21 @@ and replace it with a new one (at a new inode). The Linux standard script
 option.  With that option, `logrotate` will copy files, operate on the copies,
 and truncate the original so that the inode remains the same.
 
-This comes closest to ensuring that programs watching these files (including
-`remote_syslog`) will not be affected by, or need to be notified of, the
-rotation. The only tradeoff of `copytruncate` is slightly higher disk usage
-during rotation, so we recommend this option whether or not you use
-`remote_syslog`.
+`remote_syslog` will handle both approaches seamlessly, so it should be no
+concern as to which method is used. If a log file is moved or renamed, 
+and a new file is created (at a new inode), `remote_syslog` will follow that
+new file at the new inode (assuming it has the same absolute path name). If
+a file is copied then truncated, `remote_syslog` will seek to the beginning of
+the truncated file continue to read it.
+
+#### Log rotation edge cases to be aware of
+
+Some logging programs such as Java's gclog (`-XX:+PrintGC` or `-verbose:gc`)
+do not log in append mode, so if another program such as `logrotate` (set to
+`copytruncate`) truncates the file, on the next write of the Java logger, the
+OS will fill the file with NUL bytes upto the current offset of the file descriptor.
+More info on that [here](http://stackoverflow.com/questions/8353401/garbage-collector-log-loggc-file-rotation-with-logrotate-does-not-work-properl).
+`remote_syslog` will detect those leading NUL bytes, discard them, and log the discard count.
 
 
 ### Excluding files from being sent

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -254,12 +254,16 @@ func (s *testSyslogServer) serve() {
 						continue
 					}
 
+					fmt.Printf(line)
 					packet, err := syslog.Parse(strings.TrimRight(line, "\n"))
 					if err != nil {
 						panic(err)
 					}
 
-					s.packets <- packet
+					select {
+					case s.packets <- packet:
+					case <-time.After(time.Second):
+					}
 				}
 			}
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -114,10 +114,10 @@
 			"revisionTime": "2016-11-15T00:28:15Z"
 		},
 		{
-			"checksumSHA1": "bxKDUFzzl81g5apnjRKVr5e0Cw4=",
+			"checksumSHA1": "ZnoFXmQ+DSHU1OMWqPWOGYxlv7g=",
 			"path": "github.com/papertrail/go-tail/follower",
-			"revision": "c08f359f0f47b6a0a603b526a012fcc8924a65b0",
-			"revisionTime": "2016-11-15T00:28:15Z"
+			"revision": "39566fbcbaada1657f8c074dc55a1314e913fc8c",
+			"revisionTime": "2016-11-16T22:37:32Z"
 		},
 		{
 			"checksumSHA1": "8Y05Pz7onrQPcVWW6JStSsYRh6E=",


### PR DESCRIPTION
Incorporates the fix from https://github.com/papertrail/go-tail/pull/1

The result of this bug was memory growth tied to the amount of null bytes in a truncated file.