### PR TITLE
New go-tail, which periodically checks inode numbers

### DIFF
--- a/vendor/github.com/papertrail/go-tail/follower/follower.go
+++ b/vendor/github.com/papertrail/go-tail/follower/follower.go
@@ -222,13 +222,18 @@ func (t *Follower) follow() error {
 		// stat the file, if it's still there, just continue and try to read bytes
 		// if not, go through our re-opening routine
 		case <-time.After(10 * time.Second):
-			_, err := t.file.Stat()
-			if err == nil {
-				continue
+			fi1, err := t.file.Stat()
+			if err != nil && !os.IsNotExist(err) {
+				return err
 			}
 
-			if !os.IsNotExist(err) {
+			fi2, err := os.Stat(t.filename)
+			if err != nil && !os.IsNotExist(err) {
 				return err
+			}
+
+			if os.SameFile(fi1, fi2) {
+				continue
 			}
 
 			if err := t.rewatch(); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -108,16 +108,10 @@
 			"revision": "b30dcbfa86e3a1eaa4e6622de2ce57be2c138c10"
 		},
 		{
-			"checksumSHA1": "2aD8Ll16aJCh32lm09ow88q0BO4=",
-			"path": "github.com/papertrail/go-tail",
-			"revision": "c08f359f0f47b6a0a603b526a012fcc8924a65b0",
-			"revisionTime": "2016-11-15T00:28:15Z"
-		},
-		{
-			"checksumSHA1": "ZnoFXmQ+DSHU1OMWqPWOGYxlv7g=",
+			"checksumSHA1": "rWc9yrqpLqyvgeyOxQhO0sDPT98=",
 			"path": "github.com/papertrail/go-tail/follower",
-			"revision": "39566fbcbaada1657f8c074dc55a1314e913fc8c",
-			"revisionTime": "2016-11-16T22:37:32Z"
+			"revision": "e2752ede6edd8ce2a834603866f118eed9da0d4b",
+			"revisionTime": "2017-02-10T22:15:38Z"
 		},
 		{
 			"checksumSHA1": "8Y05Pz7onrQPcVWW6JStSsYRh6E=",


### PR DESCRIPTION
See https://github.com/papertrail/go-tail/pull/2 for details. Also removed `github.com/papertrail/go-tail` package from `vendor.json` file, since it was unused and causing warnings with `govendor status`.