### PR TITLE
Docker example - Boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,22 @@ Placing remote_syslog2 inside of a base centos/ubuntu/debian would result in a l
 Install docker on your host, typically via a package manager,
 be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
 
+### Build and Run (with docker cli):
 
+    # same directory as Dockerfile
+    # change version based on packages available on release page
+    docker build --build-arg VERSION=v0.19 -t rs2  .
 
+A successful build message should be produced after the build command.
+`docker images` will reveal image size and name.
 
-### Build and Run:
+run (in background, _docker ps_ to confirm)
+    docker run --name rs2 -d rs2`
 
-    docker build --build-arg VERSION=v0.19  -t rs2  .
+If docker ps returns an empty table check the docker container's stdout
+    docker logs rs2
 
+This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Configuration directives can also be specified as command-line arguments (below)
       -p, --dest-port int                 Destination syslog port (default 514)
           --eventmachine-tail             No action, provided for backwards compatibility
       -f, --facility string               Facility (default "user")
-          --hostname string               Local hostname to send from (default: OS hostname)
+          --hostname string               Local hostname to send from (default "mmartin-mb")
           --log string                    Set loggo config, like: --log="<root>=DEBUG" (default "<root>=INFO")
           --new-file-check-interval int   How often to check for new files (seconds) (default 10)
       -D, --no-detach                     Don't daemonize and detach from the terminal; overrides --debug-log-cfg

--- a/README.md
+++ b/README.md
@@ -270,6 +270,27 @@ destination:
 
 This functionality was introduced in version 0.17
 
+## Running inside a Docker Container
+
+If your existing infrastructure is container based (docker) you might be hesitant
+to place remote_syslog2 on your host running wild from your container orchestration;
+Or if you want to develop and test  without "tainting" your enviroment.
+
+Placing remote_syslog2 inside of a base centos/ubuntu/debian would result in a large (docker) image, basing it off of busybox or any small distro (tinycore anyone?) can leave you with a functional remote_syslog2 < 50MB.
+
+### Prerequiste 
+
+Install docker on your host, typically via a package manager,
+be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
+
+
+
+
+### Build and Run:
+
+    docker build --build-arg VERSION=v0.19  -t rs2  .
+
+
 ## Troubleshooting
 
 ### Generate debug log

--- a/README.md
+++ b/README.md
@@ -270,42 +270,6 @@ destination:
 
 This functionality was introduced in version 0.17
 
-## Running inside a Docker Container
-
-If your existing infrastructure is container based (docker) you might be hesitant
-to place remote_syslog2 on your host running wild from your container orchestration;
-Or if you want to develop and test  without "tainting" your enviroment.
-
-Placing remote_syslog2 inside of a base centos/ubuntu/debian would result in a large (docker) image, basing it off of busybox or any small distro (tinycore anyone?) can leave you with a functional remote_syslog2 < 50MB.
-
-### Prerequiste 
-
-Install docker on your host, typically via a package manager,
-be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
-
-### Build and Run (with docker cli):
-
-    # same directory as Dockerfile
-    # change version based on packages available on release page
-    docker build --build-arg VERSION=v0.19 -t rs2  .
-
-A successful build message should be produced after the build command.
-`docker images` will reveal image size and name.
-
-run (in background, _docker ps_ to confirm)
-
-    docker run --name rs2 -d rs2
-
-If `docker ps` returns an empty table check the docker container's stdout
-
-    docker logs rs2
-
-This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed.
-
-###Volumes and docker
-
-Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this directory
-
 ## Troubleshooting
 
 ### Generate debug log

--- a/README.md
+++ b/README.md
@@ -293,12 +293,18 @@ A successful build message should be produced after the build command.
 `docker images` will reveal image size and name.
 
 run (in background, _docker ps_ to confirm)
-    docker run --name rs2 -d rs2`
 
-If docker ps returns an empty table check the docker container's stdout
+    docker run --name rs2 -d rs2
+
+If `docker ps` returns an empty table check the docker container's stdout
+
     docker logs rs2
 
 This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed.
+
+###Volumes and docker
+
+Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this directory
 
 ## Troubleshooting
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,3 +27,8 @@ This is a systemd service configuration file.  Place this file at `/etc/systemd/
 ## remote_syslog.upstart.conf
 
 This is an upstart configuration file.  Place this file at `/etc/init/remote_syslog.conf` and then run `sudo start remote_syslog` to start the service.
+
+## docker/Dockerfile
+
+This is an example Dockerfile. Instructions for building and runing are detailed within.
+

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.6
-#MAINTAINER
+MAINTAINER <gitusernameplusgithub@gmail.com>
 
 # every system is different - every package unique
 # remote_syslog2 works with docker - remote_syslog2 breaks with docker
 
-# tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
+# tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (< image)
 ARG VERSION
 
 RUN addgroup -g 9999 rs2
@@ -19,14 +19,12 @@ RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION
 
 RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
-#package path changes will break dockerfile at this point
+#package/tarball path changes will break dockerfile at this point
 RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
 RUN mv /remote_syslog/example_config.yml /etc/log_files.yml
 
 RUN chown rs2:rs2 /usr/local/bin/remote_syslog
-
 USER rs2
-
 CMD ["remote_syslog", "-D" ]
 
 ## uncomment to debug container

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
-MAINTAINER
+#MAINTAINER
 
 # every system is different - every package unique
 # remote_syslog2 works with docker - remote_syslog2 breaks with docker
@@ -7,17 +7,20 @@ MAINTAINER
 # tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
 ARG VERSION
 
-RUN addgroup -g 9999 RS2
-RUN adduser -u 9999 -D -G RS2 -k /etc/rs2 -H RS2
+RUN addgroup -g 9999 rs2
+RUN adduser -u 9999 -D -G rs2 -k /etc/rs2 -H rs2
 
 RUN apk update \
   && apk add ca-certificates wget \
   && update-ca-certificates 
 
-#build arg used to pull desired versions - docker cli 
-
+##build arg used to pull desired versions - docker cli 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION/remote_syslog_linux_amd64.tar.gz
 
 RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
-CMD ["/usr/bin/tail", "-f", "/tmp/foo"]
+USER rs2
+
+## uncomment to debug container (using docker cli)
+#RUN touch /tmp/foo
+#CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -19,12 +19,16 @@ RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION
 
 RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
+#package path changes will break dockerfile at this point
 RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
+RUN mv /remote_syslog/example_config.yml /etc/log_files.yml
 
 RUN chown rs2:rs2 /usr/local/bin/remote_syslog
 
 USER rs2
 
-## uncomment to debug container (using docker cli)
+CMD ["remote_syslog", "-D" ]
+
+## uncomment to debug container
 #RUN touch /tmp/foo
 #CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,1 +1,9 @@
-FROM alpine:3.6 
+FROM alpine:3.6
+
+##
+#
+#
+#
+##
+
+

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.6 

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -22,6 +22,10 @@ RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
 RUN mv /remote_syslog/example_config.yml /etc/log_files.yml
 
+#Define the files/directory for host mounting
+#directory under "/var/log/"
+VOLUME ["/locallog.txt"]
+
 RUN chown rs2:rs2 /usr/local/bin/remote_syslog
 USER rs2
 CMD ["remote_syslog", "-D" ]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,9 +1,20 @@
 FROM alpine:3.6
+#MAINTAINER 
 
 ##
 #
-#
+# every system is different - every package unique
+# remote_syslog2 works with docker - remote_syslog2 breaks with docker
 #
 ##
 
+#v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
 
+RUN apk update \
+  && apk add ca-certificates wget \
+  && update-ca-certificates 
+
+RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.19/remote_syslog_linux_amd64.tar.gz
+
+
+CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,20 +1,19 @@
 FROM alpine:3.6
-#MAINTAINER 
+#MAINTAINER
 
-##
-#
 # every system is different - every package unique
 # remote_syslog2 works with docker - remote_syslog2 breaks with docker
-#
-##
 
-#v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
+# tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
+ARG VERSION
 
 RUN apk update \
   && apk add ca-certificates wget \
   && update-ca-certificates 
 
-RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.19/remote_syslog_linux_amd64.tar.gz
+#build arg used to pull desired versions - docker cli 
+
+RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION/remote_syslog_linux_amd64.tar.gz
 
 
 CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -16,7 +16,6 @@ RUN apk update \
 
 ##build arg used to pull desired versions - docker cli 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION/remote_syslog_linux_amd64.tar.gz
-
 RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
 #package/tarball path changes will break dockerfile at this point

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,11 +1,14 @@
 FROM alpine:3.6
-#MAINTAINER
+MAINTAINER
 
 # every system is different - every package unique
 # remote_syslog2 works with docker - remote_syslog2 breaks with docker
 
 # tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (>image)
 ARG VERSION
+
+RUN addgroup -g 9999 RS2
+RUN adduser -u 9999 -D -G RS2 -k /etc/rs2 -H RS2
 
 RUN apk update \
   && apk add ca-certificates wget \
@@ -15,5 +18,6 @@ RUN apk update \
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION/remote_syslog_linux_amd64.tar.gz
 
+RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
 CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -19,6 +19,10 @@ RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION
 
 RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 
+RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
+
+RUN chown rs2:rs2 /usr/local/bin/remote_syslog
+
 USER rs2
 
 ## uncomment to debug container (using docker cli)

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -22,14 +22,15 @@ RUN tar -xvf remote_syslog_linux_amd64.tar.gz
 RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
 RUN mv /remote_syslog/example_config.yml /etc/log_files.yml
 
-#Define the files/directory for host mounting
-#directory under "/var/log/"
-VOLUME ["/locallog.txt"]
+#Define the directories for -v flag
+#VOLUME ["/var/log/foobar/"]
+RUN touch /locallog.txt
+RUN chown rs2:rs2 /locallog.txt
 
+#run rs2 as user in production
 RUN chown rs2:rs2 /usr/local/bin/remote_syslog
 USER rs2
 CMD ["remote_syslog", "-D" ]
 
 ## uncomment to debug container
-#RUN touch /tmp/foo
 #CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -4,7 +4,7 @@ If your existing infrastructure is container based (docker) you might be hesitan
 to place remote_syslog2 on your host running wild from your container orchestration;
 Or if you want to develop and test  without "tainting" your enviroment.
 
-Placing remote_syslog2 inside of a base centos/ubuntu/debian would result in a large (docker) image, basing it off of busybox or any small distro (tinycore anyone?) can leave you with a functional remote_syslog2 < 50MB.
+Placing remote_syslog2 inside of a base centos/ubuntu/debian image would result in a large filesize (>200MB), basing it off of busybox or any small distro can leave you with a functional remote_syslog2 < 50MB.
 
 ### Prerequiste 
 
@@ -13,24 +13,60 @@ be warned you may have stale packages on your system, check docker's latest docu
 
 ### Build and Run (with docker cli):
 
-    # same directory as Dockerfile
-    # change version based on packages available on release page
-    docker build --build-arg VERSION=v0.19 -t rs2  .
+    #change version based on packages available on release page
+    docker build --build-arg VERSION=v0.19 -t rs2:latest  .
 
-A successful build message should be produced after the build command.
+After the build command a successfully built message should be produced.
 `docker images` will reveal image size and name.
 
 run (in background, _docker ps_ to confirm)
 
-    docker run --name rs2 -d rs2
+    docker run --name rs2 -d rs2:latest
+
 
 If `docker ps` returns an empty table check the docker container's stdout
 
     docker logs rs2
 
-This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed.
+This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed OR container did not start.
 
-###Volumes and docker
+### Volumes and docker
 
-Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this directory
+Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this  shared directory.
 
+### Sending logs from the host
+
+use the docker cli to mount a host directory OR a single file, ie (/var/log/foobar) OR /locallog.txt
+    
+    docker run --name rs2 -v /host/absolute/path/to/a/file/on/host/locallog.txt:/locallog.txt -d rs2:latest
+
+confirm functionality
+    
+    docker logs rs2
+    # output
+    2017-08-06 18:40:36 INFO  remote_syslog.go:55 Connecting to logs.papertrailapp.com:514 over tls
+    2017-08-06 18:40:36 INFO  remote_syslog.go:202 Forwarding file: locallog.txt
+    # continual writes are "picked up by a daemon"
+    lsof /host/absolute/path/to/a/file/locallog.txt
+    # snippet
+    1 COMMAND     PID     USER   FD   TYPE DEVICE SIZE/OFF     NODE NAME
+    2 remote_sy 15465     9999    6r   REG    9,3       11 10224554 /host/absolute/path/to/a/file/locallog.txt
+
+### Debugging
+
+Removing the comment lines at the bottom of the dockerfile, rebuild the image, and run the container. You can use the following command `docker exec -it -u 0 sh` to "enter" the container as root, manually run remote_syslog2 via the cli and debug from there.
+
+### Afterword
+
+Keep the image minimal so it can be re-deployed in your enviroments. 
+
+Use enviroment variables to manipulate remote_syslog2's configuration - docs.docker.com (search ENV) 
+OR volume mount a configuration file `/etc/log_files.yml`
+
+Use the docker cli for debugging/testing/development/prototyping, any other use-case should invole orchestration;
+
+docs.docker.com (search docker-compose)
+
+google.com (search marathon)
+
+Managing multiple volumes (log files/directories that contain logs) is managable and extensible with proper container orchestration; additionaly steps should be taken in production enviroments to ensure reads/writes/truncating/rotation etc is done properly within docker volumes (fine tunning the enviroment)

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,36 @@
+## Running inside a Docker Container
+
+If your existing infrastructure is container based (docker) you might be hesitant
+to place remote_syslog2 on your host running wild from your container orchestration;
+Or if you want to develop and test  without "tainting" your enviroment.
+
+Placing remote_syslog2 inside of a base centos/ubuntu/debian would result in a large (docker) image, basing it off of busybox or any small distro (tinycore anyone?) can leave you with a functional remote_syslog2 < 50MB.
+
+### Prerequiste 
+
+Install docker on your host, typically via a package manager,
+be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
+
+### Build and Run (with docker cli):
+
+    # same directory as Dockerfile
+    # change version based on packages available on release page
+    docker build --build-arg VERSION=v0.19 -t rs2  .
+
+A successful build message should be produced after the build command.
+`docker images` will reveal image size and name.
+
+run (in background, _docker ps_ to confirm)
+
+    docker run --name rs2 -d rs2
+
+If `docker ps` returns an empty table check the docker container's stdout
+
+    docker logs rs2
+
+This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed.
+
+###Volumes and docker
+
+Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this directory
+

--- a/examples/log_files.yml.example.advanced
+++ b/examples/log_files.yml.example.advanced
@@ -2,10 +2,6 @@
 files: 
   - /var/log/httpd/access_log
   - /var/log/httpd/error_log
-  - path: /var/log/httpd/site2/access_log
-    tag: site2/access_log
-  - path: /var/log/httpd/site2/error_log
-    tag: site2/error_log
   - /opt/misc/*.log
   - /home/**/*.log
   - /var/log/mysqld.log
@@ -21,6 +17,4 @@ destination:
   host: HOST.papertrailapp.com # NOTE: change this to YOUR papertrail host!
   port: 12345   # NOTE: change this to YOUR papertrail port!
   protocol: tls
-facility: local7
-severity: warn
 new_file_check_interval: "10" # Check every 10 seconds

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -108,10 +108,10 @@
 			"revision": "b30dcbfa86e3a1eaa4e6622de2ce57be2c138c10"
 		},
 		{
-			"checksumSHA1": "yVIJdaWkoUJbEhvujesED4rqAnE=",
+			"checksumSHA1": "rWc9yrqpLqyvgeyOxQhO0sDPT98=",
 			"path": "github.com/papertrail/go-tail/follower",
-			"revision": "1b77c8dfcc6baca12dedfab119135396782b68a1",
-			"revisionTime": "2017-08-01T20:12:34Z"
+			"revision": "e2752ede6edd8ce2a834603866f118eed9da0d4b",
+			"revisionTime": "2017-02-10T22:15:38Z"
 		},
 		{
 			"checksumSHA1": "8Y05Pz7onrQPcVWW6JStSsYRh6E=",


### PR DESCRIPTION
My hope is that this image can be throughly documented  so remote_syslog2 (**rs2**) can have a docker image for contributors to build on.
tested user
`    1 rs2        0:00 remote_syslog -D`
tested output
`2017-07-19 23:52:07 INFO  remote_syslog.go:55 Connecting to logs.papertrailapp.com:514 over tls`
build instructions
`docker build --build-arg VERSION=v0.19  -t rs2  .`
run (in background, _docker ps_ to confirm)
`docker run --name rs2 -d rs2`
**TODO: Documentation**
This baseplate should have documentation that only corresponds to the docker CLI, very basic starting/stop/removing  containers, confirming that logs send correctly + simple exampling, passing ENV variables to container to manipulate remote_syslog2 cli


