### PR TITLE
New daemonize to eliminate cgo

### DIFF
--- a/utils/setsid_unix.go
+++ b/utils/setsid_unix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package utils
+
+import "syscall"
+
+func setsidAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/utils/setsid_windows.go
+++ b/utils/setsid_windows.go
@@ -1,0 +1,8 @@
+package utils
+
+import "syscall"
+
+func setsidAttr() *syscall.SysProcAttr {
+	CREATE_NO_WINDOW := uint32(0x08000000)
+	return &syscall.SysProcAttr{CreationFlags: CREATE_NO_WINDOW}
+}


### PR DESCRIPTION
Changed `Daemonize()` to use an new `daemonize()` implementation that doesn't rely on cgo at all. This ought to make it easier to build for more operating systems, such as FreeBSD (see #156).

The new `daemonize()` completes steps 5-9 and 11 (and 14-15 to some extent) from [this list](https://www.freedesktop.org/software/systemd/man/daemon.html). These steps all come "for free" with various options to `os.StartProcess()`. The missing steps would either need the syscall package or weren't clearly needed.

Compared to [VividCortex/godaemon](https://github.com/VividCortex/godaemon), the only real difference is that there's no [syscall.Umask(0)](https://github.com/VividCortex/godaemon/blob/master/daemon.go#L217), which is step 10 from the list above. It's also used differently:

```go
if !isDaemonized() {
	// put any one-time init here, not repeated in children
	err = daemonize([]*os.File{newStdin, newStdout, newStderr, ...})
	if err != nil {
		os.Exit(1)
	}
}
// continue here
```

Probably best to compare [old](https://github.com/papertrail/remote_syslog2/blob/master/utils/daemonize.go) vs. [new](https://github.com/papertrail/remote_syslog2/blob/new-daemon/utils/daemonize.go) side-by-side, since the diff is hard to follow.

Wouldn't necessarily be opposed to adding more (e.g. `syscall.Umask(0)`), but this seems like a good starting point.