### PR TITLE
Docker example 2

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM alpine:3.6
+MAINTAINER <gitusernameplusgithub@gmail.com>
+
+# every system is different - every package unique
+# remote_syslog2 works with docker - remote_syslog2 breaks with docker
+
+# tested with v0.19 release - hardcoded -pull precompiled binares OR compile in dockerfile (< image)
+ARG VERSION
+
+RUN addgroup -g 9999 rs2
+RUN adduser -u 9999 -D -G rs2 -k /etc/rs2 -H rs2
+
+RUN apk update \
+  && apk add ca-certificates wget \
+  && update-ca-certificates 
+
+##build arg used to pull desired versions - docker cli 
+RUN wget https://github.com/papertrail/remote_syslog2/releases/download/$VERSION/remote_syslog_linux_amd64.tar.gz
+RUN tar -xvf remote_syslog_linux_amd64.tar.gz
+
+#package/tarball path changes will break dockerfile at this point
+RUN mv remote_syslog/remote_syslog /usr/local/bin/remote_syslog
+RUN mv /remote_syslog/example_config.yml /etc/log_files.yml
+
+#Define the directories for -v flag
+#VOLUME ["/var/log/foobar/"]
+RUN touch /locallog.txt
+RUN chown rs2:rs2 /locallog.txt
+
+#run rs2 as user in production
+RUN chown rs2:rs2 /usr/local/bin/remote_syslog
+USER rs2
+CMD ["remote_syslog", "-D" ]
+
+## uncomment to debug container
+#CMD ["/usr/bin/tail", "-f", "/tmp/foo"]

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,12 +1,12 @@
-## Running inside a Docker Container
+﻿## Running inside a Docker Container
 
 If your existing infrastructure is container based (docker) you might be hesitant
 to place remote_syslog2 on your host running wild from your container orchestration;
-Or if you want to develop and test  without "tainting" your enviroment.
+Or if you want to develop and test  without "tainting" your environment.
 
-Placing remote_syslog2 inside of a base centos/ubuntu/debian image would result in a large filesize (>200MB), basing it off of busybox or any small distro can leave you with a functional remote_syslog2 < 50MB.
+Placing remote_syslog2 inside of a base centos/ubuntu/debian image would result in a large file size (>200MB), basing it off of busybox or any small distro can leave you with a functional remote_syslog2 < 50MB.
 
-### Prerequiste 
+### Prerequisite 
 
 Install docker on your host, typically via a package manager,
 be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
@@ -54,13 +54,13 @@ confirm functionality
 
 ### Debugging
 
-Removing the comment lines at the bottom of the dockerfile, rebuild the image, and run the container. You can use the following command `docker exec -it -u 0 sh` to "enter" the container as root, manually run remote_syslog2 via the cli and debug from there.
+Remove the comment lines at the bottom of the dockerfile, rebuild the image, and run the container. You can use the following command `docker exec -it -u 0 sh` to "enter" the container as root, manually run remote_syslog2 via the cli and debug from there.
 
 ### Afterword
 
 Keep the image minimal so it can be re-deployed in your enviroments. 
 
-Use enviroment variables to manipulate remote_syslog2's configuration - docs.docker.com (search ENV) 
+Use environment variables to manipulate remote_syslog2's configuration - docs.docker.com (search ENV) 
 OR volume mount a configuration file `/etc/log_files.yml`
 
 Use the docker cli for debugging/testing/development/prototyping, any other use-case should invole orchestration;
@@ -69,4 +69,4 @@ docs.docker.com (search docker-compose)
 
 google.com (search marathon)
 
-Managing multiple volumes (log files/directories that contain logs) is managable and extensible with proper container orchestration; additionaly steps should be taken in production enviroments to ensure reads/writes/truncating/rotation etc is done properly within docker volumes (fine tunning the enviroment)
+Managing multiple volumes (log files/directories that contain logs) is manageable and extensible with proper container orchestration; additionally steps should be taken in production environments to ensure reads/writes/truncating/rotation etc is done properly within docker volumes (fine tunning the environment)

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,72 @@
+## Running inside a Docker Container
+
+If your existing infrastructure is container based (docker) you might be hesitant
+to place remote_syslog2 on your host running wild from your container orchestration;
+Or if you want to develop and test  without "tainting" your enviroment.
+
+Placing remote_syslog2 inside of a base centos/ubuntu/debian image would result in a large filesize (>200MB), basing it off of busybox or any small distro can leave you with a functional remote_syslog2 < 50MB.
+
+### Prerequiste 
+
+Install docker on your host, typically via a package manager,
+be warned you may have stale packages on your system, check docker's latest documentation to insure you install the right package. (https://docs.docker.com/search/?q=install).
+
+### Build and Run (with docker cli):
+
+    #change version based on packages available on release page
+    docker build --build-arg VERSION=v0.19 -t rs2:latest  .
+
+After the build command a successfully built message should be produced.
+`docker images` will reveal image size and name.
+
+run (in background, _docker ps_ to confirm)
+
+    docker run --name rs2 -d rs2:latest
+
+
+If `docker ps` returns an empty table check the docker container's stdout
+
+    docker logs rs2
+
+This will produce errors from the container's daemonized process (remote_syslog2) which should be a decent hint as to why it crashed OR container did not start.
+
+### Volumes and docker
+
+Utilize a docker volume to access logs on the host or another container, between two (or more) containers share a docker volume and point the directories in `log _files.yml` at this  shared directory.
+
+### Sending logs from the host
+
+use the docker cli to mount a host directory OR a single file, ie (/var/log/foobar) OR /locallog.txt
+    
+    docker run --name rs2 -v /host/absolute/path/to/a/file/on/host/locallog.txt:/locallog.txt -d rs2:latest
+
+confirm functionality
+    
+    docker logs rs2
+    # output
+    2017-08-06 18:40:36 INFO  remote_syslog.go:55 Connecting to logs.papertrailapp.com:514 over tls
+    2017-08-06 18:40:36 INFO  remote_syslog.go:202 Forwarding file: locallog.txt
+    # continual writes are "picked up by a daemon"
+    lsof /host/absolute/path/to/a/file/locallog.txt
+    # snippet
+    1 COMMAND     PID     USER   FD   TYPE DEVICE SIZE/OFF     NODE NAME
+    2 remote_sy 15465     9999    6r   REG    9,3       11 10224554 /host/absolute/path/to/a/file/locallog.txt
+
+### Debugging
+
+Removing the comment lines at the bottom of the dockerfile, rebuild the image, and run the container. You can use the following command `docker exec -it -u 0 sh` to "enter" the container as root, manually run remote_syslog2 via the cli and debug from there.
+
+### Afterword
+
+Keep the image minimal so it can be re-deployed in your enviroments. 
+
+Use enviroment variables to manipulate remote_syslog2's configuration - docs.docker.com (search ENV) 
+OR volume mount a configuration file `/etc/log_files.yml`
+
+Use the docker cli for debugging/testing/development/prototyping, any other use-case should invole orchestration;
+
+docs.docker.com (search docker-compose)
+
+google.com (search marathon)
+
+Managing multiple volumes (log files/directories that contain logs) is managable and extensible with proper container orchestration; additionaly steps should be taken in production enviroments to ensure reads/writes/truncating/rotation etc is done properly within docker volumes (fine tunning the enviroment)


### PR DESCRIPTION
this is a re-branch of #204 w/ spelling corrections in the README, too many commits in the old branch.

Motivation: use in my personal website that is docker based.

use case for anyone using docker across their infrastructure, if service(s) run inside containers remote_syslog2 would need to run inside a container - in order to access the _file system_ * properly to ensure those service(s) remain properly configured with respect to r/w/x.

*_file system_ could be block storage like devicemapper or LVM or something like OverlayFS.

Copy paste from #204 

tested user
`    1 rs2        0:00 remote_syslog -D`
tested output
`2017-07-19 23:52:07 INFO  remote_syslog.go:55 Connecting to logs.papertrailapp.com:514 over tls`
build instructions
`docker build --build-arg VERSION=v0.19  -t rs2  .`
run (in background, _docker ps_ to confirm)
`docker run --name rs2 -d rs2`
