### PR TITLE
Mention YUM repository (CentOS / RedHat 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The repository in question automatically builds latest GitHub release of `remote
     yum install remote_syslog2
     sudo systemctl start remote_syslog
     
-Now edit `/etc/log_files.yml` with your host and port, then start the service:
+Now edit `/etc/log_files.yml` with your host, port and relevant list of log files. After that start the service:
 
     sudo systemctl start remote_syslog
     

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ option or the `-d` invocation flag are required.
 
 ## Installing
 
+### Quick setup with YUM repository for CentOS 7
+
+Using `yum` repository provides a convinient way to fetch the most recent version of `remote_syslog2`.
+The repository in question automatically builds latest GitHub release of `remote_syslog2`, in no later than 24 hrs.
+
+    yum install https://extras.getpagespeed.com/release-el7-latest.rpm
+    yum install remote_syslog2
+    sudo systemctl start remote_syslog
+    
+Now edit `/etc/log_files.yml` with your host and port, then start the service:
+
+    sudo systemctl start remote_syslog
+    
+### Precompiled binaries    
+
 Precompiled binaries for Mac (Darwin), Linux and Windows are available on the
 [remote_syslog2 releases page][releases].
 


### PR DESCRIPTION
I think it's most convinient for end users to install remote_syslog2 using YUM repository. On CentOS 7 it's possible using instructions in updated Readme file.