### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/config.go
+++ b/config.go
@@ -143,7 +143,7 @@ func initConfigAndFlags() {
 	config.AutomaticEnv()
 }
 
-// Read in configuration from environment, flags, and specified or default config file.
+// NewConfigFromEnv reads in configuration from environment, flags, and specified or default config file.
 func NewConfigFromEnv() (*Config, error) {
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return nil, err

--- a/papertrail/root_ca.go
+++ b/papertrail/root_ca.go
@@ -3904,7 +3904,7 @@ LEL2TxyJeN4mTvVvk0wVaydWTQBUbHq3tw==
 	return []byte(s)
 }
 
-// Returns an *x509.CertPool that can be used to verify the certificate
+// RootCA returns an *x509.CertPool that can be used to verify the certificate
 // provided by logs.papertrailapp.com. For historical reasons this cert
 // cannot be verified using the default certs provided on many systems.
 func RootCA() *x509.CertPool {

--- a/syslog/packet.go
+++ b/syslog/packet.go
@@ -19,7 +19,7 @@ type Packet struct {
 // like time.RFC3339Nano but with a limit of 6 digits in the SECFRAC part
 const rfc5424time = "2006-01-02T15:04:05.999999Z07:00"
 
-// The combined Facility and Severity of this packet. See RFC5424 for details.
+// Priority: The combined Facility and Severity of this packet. See RFC5424 for details.
 func (p Packet) Priority() Priority {
 	return (p.Facility << 3) | p.Severity
 }
@@ -45,7 +45,7 @@ func (p Packet) Generate(max_size int) string {
 	}
 }
 
-// A convenience function for testing
+// Parse: A convenience function for testing
 func Parse(line string) (Packet, error) {
 	var (
 		packet   Packet


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say **`opt out`** to opt out of future CodeLingo outreach PRs.*