### PR TITLE
Fix govet errors in syslog tests

### DIFF
--- a/syslog/packet_test.go
+++ b/syslog/packet_test.go
@@ -17,7 +17,7 @@ func TestPacketPriority(t *testing.T) {
 	for _, test := range tests {
 		p := Packet{Severity: test.severity, Facility: test.facility}
 		if result := p.Priority(); result != test.priority {
-			t.Errorf("Bad priority, got %s expected %d", result, test.priority)
+			t.Errorf("Bad priority, got %d expected %d", result, test.priority)
 		}
 	}
 }

--- a/syslog/syslog_test.go
+++ b/syslog/syslog_test.go
@@ -12,7 +12,7 @@ import (
 
 const clienthost = "clienthost"
 
-func panicf(s string, i ...interface{}) { panic(fmt.Sprintf(s, i)) }
+func panicf(s string, i ...interface{}) { panic(fmt.Sprintf(s, i...)) }
 
 type testServer struct {
 	Addr     string

--- a/utils/daemonize.go
+++ b/utils/daemonize.go
@@ -28,7 +28,7 @@ func Daemonize(logFilePath, pidFilePath string) {
 	if os.Getenv("__DAEMON_CWD") == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "Cannot determine working directory: %v", err)
+			fmt.Fprintf(os.Stderr, "Cannot determine working directory: %v\n", err)
 			os.Exit(1)
 		}
 		os.Setenv("__DAEMON_CWD", cwd)
@@ -36,13 +36,13 @@ func Daemonize(logFilePath, pidFilePath string) {
 
 	logFile, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Could not open local log file: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not open local log file: %v\n", err)
 		os.Exit(1)
 	}
 
 	stdout, stderr, err := godaemon.MakeDaemon(&godaemon.DaemonAttr{CaptureOutput: true})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Could not Daemonize: %v", err)
+		fmt.Fprintf(os.Stderr, "Could not Daemonize: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -56,7 +56,7 @@ func Daemonize(logFilePath, pidFilePath string) {
 	lock, err := lockfile.New(pidFilePath)
 	err = lock.TryLock()
 	if err != nil {
-		fmt.Println("Cannot lock \"%v\": %v", lock, err)
+		fmt.Fprintf(os.Stderr, "Cannot lock \"%v\": %v\n", lock, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This fixes govet errors in the syslog package's test files, which were causing `go test` to fail for newer versions of Go which run vet when testing.