### PR TITLE
Config option to append the filename to the tag

### DIFF
--- a/config.go
+++ b/config.go
@@ -65,6 +65,7 @@ type Config struct {
 type LogFile struct {
 	Path string
 	Tag  string
+	AppendPath bool
 }
 
 func init() {
@@ -312,16 +313,18 @@ func decodeLogFiles(f interface{}) ([]LogFile, error) {
 			var (
 				tag  string
 				path string
+				appendPath bool
 			)
 
 			tag, _ = val["tag"].(string)
 			path, _ = val["path"].(string)
+			appendPath, _ = val["appendPath"].(bool)
 
 			if path == "" {
 				return files, fmt.Errorf("Invalid log file %#v", val)
 			}
 
-			files = append(files, LogFile{Tag: tag, Path: path})
+			files = append(files, LogFile{Tag: tag, Path: path, AppendPath: appendPath})
 
 		default:
 			panic(vals)

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -93,7 +93,7 @@ func (s *Server) closing() bool {
 }
 
 // Tails a single file
-func (s *Server) tailOne(file, tag string, whence int) {
+func (s *Server) tailOne(file, tag string, whence int, appendPath bool) {
 	defer s.registry.Remove(file)
 
 	t, err := follower.New(file, follower.Config{
@@ -109,6 +109,8 @@ func (s *Server) tailOne(file, tag string, whence int) {
 
 	if tag == "" {
 		tag = path.Base(file)
+	} else if appendPath == true {
+		tag = tag + path.Base(file)
 	}
 
 	for {
@@ -180,6 +182,7 @@ func (s *Server) globFiles(firstPass bool) {
 	for _, glob := range s.config.Files {
 
 		tag := glob.Tag
+		appendPath := glob.AppendPath
 		files, err := filepath.Glob(utils.ResolvePath(glob.Path))
 
 		if err != nil {
@@ -205,7 +208,7 @@ func (s *Server) globFiles(firstPass bool) {
 				}
 
 				s.registry.Add(file)
-				go s.tailOne(file, tag, whence)
+				go s.tailOne(file, tag, whence, appendPath)
 			}
 		}
 	}


### PR DESCRIPTION
We have a use case where we'd like to glob all the files in several directories and give a unique tag to each, but also preserve the filenames in the log lines. For example, if we have a couple servers logging to multiple directories under /var/log, we could do something like:

```yaml
files:
    - path: /var/log/frontend_server/*_log
      tag: frontend_server.
      appendPath: true
    - path: /var/log/backend_server/*_log
      tag: backend_server.
      appendPath: true
```

And the log lines would show up with the filenames (acceess_log/error_log) appended in papertrail: 

```
Jul 24 14:31:44 i-080808ababab frontend_server.access_log: GET /
Jul 24 14:31:44 i-080808ababab frontend_server.error_log: ERROR: 
Jul 24 14:31:44 i-080808ababab backend_server.access_log: POST /
Jul 24 14:31:44 i-080808ababab backend_server.error_log: ERROR: 
```

I was able to hack my way into something that works, but I'm not a go programmer so it might not be the correct approach. 