### PR TITLE
Add support for Loggly-style ingestion tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ Configuration directives can also be specified as command-line arguments (below)
           --debug-log-cfg string          The debug log file; overridden by -D/--no-detach
       -d, --dest-host string              Destination syslog hostname or IP
       -p, --dest-port int                 Destination syslog port (default 514)
+      -t, --dest-token string             Destination ingestion token
           --eventmachine-tail             No action, provided for backwards compatibility
       -f, --facility string               Facility (default "user")
+      -h, --help                          Display this help message
           --hostname string               Local hostname to send from (default: OS hostname)
           --log string                    Set loggo config, like: --log="<root>=DEBUG" (default "<root>=INFO")
           --new-file-check-interval int   How often to check for new files (seconds) (default 10)
@@ -73,6 +75,7 @@ Configuration directives can also be specified as command-line arguments (below)
       -s, --severity string               Severity (default "notice")
           --tcp                           Connect via TCP (no TLS)
           --tls                           Connect via TCP with TLS
+      -V, --version                       Display version and exit
 
 ## Example
 

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ type Config struct {
 		Host     string
 		Port     int
 		Protocol string
+		Token    string
 	}
 	RootCAs *x509.CertPool
 }
@@ -97,6 +98,9 @@ func initConfigAndFlags() {
 
 	flags.IntP("dest-port", "p", 514, "Destination syslog port")
 	config.BindPFlag("destination.port", flags.Lookup("dest-port"))
+
+	flags.StringP("dest-token", "t", "", "Destination ingestion token")
+	config.BindPFlag("destination.token", flags.Lookup("dest-token"))
 
 	flags.StringP("facility", "f", "user", "Facility")
 	config.BindPFlag("facility", flags.Lookup("facility"))
@@ -191,6 +195,7 @@ func NewConfigFromEnv() (*Config, error) {
 	c.Destination.Host = config.GetString("destination.host")
 	c.Destination.Port = config.GetInt("destination.port")
 	c.Destination.Protocol = config.GetString("destination.protocol")
+	c.Destination.Token = config.GetString("destination.token")
 
 	// explicitly set destination protocol if we've asked for tcp or tls
 	if c.TLS {

--- a/config_test.go
+++ b/config_test.go
@@ -26,6 +26,7 @@ func TestRawConfig(t *testing.T) {
 	assert.Equal(c.Destination.Host, "logs.papertrailapp.com")
 	assert.Equal(c.Destination.Port, 514)
 	assert.Equal(c.Destination.Protocol, "tls")
+	assert.Equal(c.Destination.Token, "0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
 	assert.Equal(c.ExcludePatterns, []*regexp.Regexp{regexp.MustCompile("don't log on me"), regexp.MustCompile(`do \w+ on me`)})
 	assert.Equal(c.ExcludeFiles, []*regexp.Regexp{regexp.MustCompile(`\.DS_Store`)})
 	assert.Equal(c.Files, []LogFile{
@@ -85,4 +86,5 @@ func TestNoConfigFile(t *testing.T) {
 	assert.Equal("localhost", c.Destination.Host)
 	assert.Equal(999, c.Destination.Port)
 	assert.Equal("udp", c.Destination.Protocol)
+	assert.Equal("", c.Destination.Token)
 }

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -141,6 +141,7 @@ func (s *Server) tailOne(file, tag string, whence int) {
 					Time:     time.Now(),
 					Hostname: s.logger.ClientHostname,
 					Tag:      tag,
+					Token:    s.config.Destination.Token,
 					Message:  l,
 				})
 

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -165,6 +165,7 @@ func testConfig() *Config {
 			Host     string
 			Port     int
 			Protocol string
+			Token    string
 		}{
 			Host:     addr.host,
 			Port:     addr.port,

--- a/syslog/packet_test.go
+++ b/syslog/packet_test.go
@@ -64,6 +64,20 @@ func TestPacketGenerate(t *testing.T) {
 			"<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc - - - %% It's time to make the do-nuts.",
 		},
 		{
+			// test ingestion token
+			Packet{
+				Severity: SevNotice,
+				Facility: LogLocal4,
+				Time:     parseTime("2003-08-24T05:14:15.000003-07:00"),
+				Hostname: "192.0.2.1",
+				Tag:      "myproc",
+				Token:    "0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
+				Message:  `%% It's time to make the do-nuts.`,
+			},
+			0,
+			"<165>1 2003-08-24T05:14:15.000003-07:00 192.0.2.1 myproc - - [0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz@41058] %% It's time to make the do-nuts.",
+		},
+		{
 			// test that fractional seconds is at most 6 digits long
 			Packet{
 				Severity: SevNotice,

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -8,6 +8,7 @@ destination:
   host: logs.papertrailapp.com
   port: 514
   protocol: tls
+  token: 0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz
 exclude_patterns:
   - don't log on me
   - do \w+ on me


### PR DESCRIPTION
Papertrail recently added support for syslog ingestion tokens using [Loggly's](https://documentation.solarwinds.com/en/success_center/loggly/content/admin/streaming-syslog-without-using-files.htm#Syslog-Header) `[TOKEN@41058]` STRUCTURED-DATA format, as an alternative to assigning unique ports to each customer. This PR allows remote_syslog2 to send using that format.

`/etc/log_files.yml` would look something like:

```yml
files:
  - /path/to/your/file.log
destination:
  host: logs.collector.solarwinds.com
  port: 6514
  protocol: tls
  token: 012345-ABCDEFGHIJ_klmnopqrst
```

Already tested it out and confirmed that logs showed up in Papertrail, using a token from **Settings** > **Log Destinations** > **Token**.