### PR TITLE
Fix panic: cannot daemonize on windows

### DIFF
--- a/config.go
+++ b/config.go
@@ -173,7 +173,7 @@ func NewConfigFromEnv() (*Config, error) {
 
 	// override daemonize setting for platforms that don't support it
 	if !utils.CanDaemonize {
-		config.Set("no_daemonize", true)
+		config.Set("no_detach", true)
 	}
 
 	// unmarshal environment config into our Config object here


### PR DESCRIPTION
We fixed #3 in #7, but then reintroduced the same bug in #170 due to a typo.