### PR TITLE
Add support for multiple logging destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ to log to (as a hash). Wildcards are supported using * and standard shell
 globbing. Filenames given on the command line are additive to those in
 the config file.
 
-Only 1 destination server is supported; the command-line argument wins.
+One main destination, and up to 10 optional destinations servers (indexed 1
+to 10) can be specified in the configuration file.
+
+Using the command-line, only a single destination can be specified, and this one overrides the destination server specified using the main 'destination' config element.
 
     files:
      - /var/log/httpd/access_log
@@ -146,6 +149,12 @@ Only 1 destination server is supported; the command-line argument wins.
       host: logs.papertrailapp.com
       port: 12345
       protocol: tls
+    destination1:
+      host: logs2.papertrailapp.com
+      port: 67890
+      protocol: tls
+    destination2:
+    ...
 
 remote_syslog sends the name of the file without a path ("mysqld.log") as
 the syslog tag (program name).

--- a/config_test.go
+++ b/config_test.go
@@ -22,10 +22,10 @@ func TestRawConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(c.Destination.Host, "logs.papertrailapp.com")
-	assert.Equal(c.Destination.Port, 514)
-	assert.Equal(c.Destination.Protocol, "tls")
-	assert.Equal(c.Destination.Token, "0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
+	assert.Equal(c.Destinations[0].Host, "logs.papertrailapp.com")
+	assert.Equal(c.Destinations[0].Port, 514)
+	assert.Equal(c.Destinations[0].Protocol, "tls")
+	assert.Equal(c.Destinations[0].Token, "0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
 	assert.Equal(c.ExcludePatterns, []*regexp.Regexp{regexp.MustCompile("don't log on me"), regexp.MustCompile(`do \w+ on me`)})
 	assert.Equal(c.ExcludeFiles, []*regexp.Regexp{regexp.MustCompile(`\.DS_Store`)})
 	assert.Equal(c.Files, []LogFile{
@@ -81,8 +81,8 @@ func TestNoConfigFile(t *testing.T) {
 	}
 
 	assert.NoError(c.Validate())
-	assert.Equal("localhost", c.Destination.Host)
-	assert.Equal(999, c.Destination.Port)
-	assert.Equal("udp", c.Destination.Protocol)
-	assert.Equal("", c.Destination.Token)
+	assert.Equal("localhost", c.Destinations[0].Host)
+	assert.Equal(999, c.Destinations[0].Port)
+	assert.Equal("udp", c.Destinations[0].Protocol)
+	assert.Equal("", c.Destinations[0].Token)
 }

--- a/examples/log_files.yml.example.advanced
+++ b/examples/log_files.yml.example.advanced
@@ -21,6 +21,10 @@ destination:
   host: HOST.papertrailapp.com # NOTE: change this to YOUR papertrail host!
   port: 12345   # NOTE: change this to YOUR papertrail port!
   protocol: tls
+destination1:
+  host: HOST1.papertrailapp.com # NOTE: change this to YOUR papertrail host!
+  port: 67890 # NOTE: change this to YOUR papertrail port!
+  protocol: tls
 facility: local7
 severity: warn
 new_file_check_interval: "10" # Check every 10 seconds

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -161,15 +161,12 @@ func testConfig() *Config {
 		Hostname:             "testhost",
 		Severity:             severity,
 		Facility:             facility,
-		Destination: struct {
-			Host     string
-			Port     int
-			Protocol string
-			Token    string
-		}{
-			Host:     addr.host,
-			Port:     addr.port,
-			Protocol: "tcp",
+		Destinations: []Destination{
+			{
+				Host:     addr.host,
+				Port:     addr.port,
+				Protocol: "tcp",
+			},
 		},
 		Files: []LogFile{
 			{


### PR DESCRIPTION
This pull request adds support for (optionally) logging to multiple syslog destinations. 

The optional destinations need to be defined in the configuration file, e.g.,

destination:
 host: some_host
 port: 12345
 protocol: tls
 token: some_token
destination1:
 host: some_host2
 port: 67890
 protocol: tls
 token: some_token
destination2:
...

The implementation supports optional destinations indexed from 1 to maxDestinationIndex (currently max 10 optional destinations).

The change is fully backwards-compatible, i.e., we always process the 'destination' config element (and the command-line destination parameter overrides the config file 'destination', as previously).

Also update the tests to use the new internal format.
