### PR TITLE
Ease use in (azure) cloud environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Configuration directives can also be specified as command-line arguments (below)
       -d, --dest-host string              Destination syslog hostname or IP
       -p, --dest-port int                 Destination syslog port (default 514)
       -t, --dest-token string             Destination ingestion token
+          --dest-uri string               Destination as a URI, overrides dest-host, dest-port, and transport
+          --domain string                 Domain suffix for hostname
           --eventmachine-tail             No action, provided for backwards compatibility
       -f, --facility string               Facility (default "user")
       -h, --help                          Display this help message
@@ -110,6 +112,21 @@ remote_syslog will daemonize by default.
 
 Additional information about init files (`init.d`, `supervisor`, `systemd` and `upstart`) are
 available [in the examples directory](examples/).
+
+
+## Deploy a kubernetes daemonset to forward container logs
+
+An example for a deployment as a [kubernetes daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+that consumes the containerd container logs is provided [in the examples directory](examples/k8s.and.containerd/).
+
+To install the daemonset on your cluster, using a pre-built container, edit the `papertrail-destination` secret inside
+`daemonset.yml` to point to the log server and port for your [papertrail account](https://papertrailapp.com/systems/setup?type=system&platform=unix) and optionally set the `domain` in the `papertrail-remote-syslog` configmap. Then apply the daemonset to your cluster:
+
+    $ kubectl apply -f examples/k8s.and.containerd/daemonset.yml
+
+Optionally you can build the container yourself:
+
+    $ docker build . -f examples/k8s.and.containerd/Dockerfile -t remote_syslog2:latest
 
 
 ## Sending messages securely ##
@@ -165,6 +182,12 @@ Here's an [advanced config](https://github.com/papertrail/remote_syslog2/blob/ma
 Provide `--hostname somehostname` or use the `hostname` configuration option:
 
     hostname: somehostname
+
+### Add domain suffix to hostname
+
+Provide `--domain some.f.q.d.n` or use the `domain` configuration option:
+
+`worker-1` becomes `worker-1.some.f.q.d.n`
 
 
 ### Detecting new files
@@ -272,6 +295,13 @@ destination:
 `remote_syslog apache=/var/log/httpd/access_log`
 
 This functionality was introduced in version 0.17
+
+#### Using regular expression matching to extract the "tag" from the file name
+
+remote_syslog allows for a regular expression to be provided for each pattern, to
+extract a meaningful name from the file names that are matched by a glob expression.
+
+`remote_syslog 're:containers/(?P<tag>.*)-.{64}.log=/var/log/containers/*.log'`
 
 ## Troubleshooting
 

--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	TLS                  bool             `mapstructure:"tls"`
 	Files                []LogFile
 	Hostname             string
+	Domain               string
 	Severity             syslog.Priority
 	Facility             syslog.Priority
 	Poll                 bool
@@ -107,6 +108,9 @@ func initConfigAndFlags() {
 	hostname, _ := os.Hostname()
 	flags.String("hostname", hostname, "Local hostname to send from")
 	config.BindPFlag("hostname", flags.Lookup("hostname"))
+
+	flags.StringP("domain", "", "", "Domain suffix for hostname")
+	config.BindPFlag("domain", flags.Lookup("domain"))
 
 	flags.String("pid-file", "", "Location of the PID file")
 	config.BindPFlag("pid_file", flags.Lookup("pid-file"))
@@ -223,6 +227,11 @@ func NewConfigFromEnv() (*Config, error) {
 }
 
 func (c *Config) Validate() error {
+	if c.Domain != "" {
+		c.Hostname = strings.TrimRight(c.Hostname, ".") + "." + strings.TrimLeft(c.Domain, ".")
+		c.Domain = ""
+	}
+
 	if c.Destination.Host == "" {
 		return fmt.Errorf("No destination hostname specified")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -86,3 +86,21 @@ func TestNoConfigFile(t *testing.T) {
 	assert.Equal("udp", c.Destination.Protocol)
 	assert.Equal("", c.Destination.Token)
 }
+
+func TestURIInConfig(t *testing.T) {
+	assert := assert.New(t)
+	initConfigAndFlags()
+
+	flags.Set("dest-uri", "syslog+tls://localhost:999")
+
+	c, err := NewConfigFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NoError(c.Validate())
+	assert.Equal("localhost", c.Destination.Host)
+	assert.Equal(999, c.Destination.Port)
+	assert.Equal("tls", c.Destination.Protocol)
+	assert.Equal("", c.Destination.Token)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -104,3 +104,73 @@ func TestURIInConfig(t *testing.T) {
 	assert.Equal("tls", c.Destination.Protocol)
 	assert.Equal("", c.Destination.Token)
 }
+
+func TestLogFileTagPatterns(t *testing.T) {
+	type tc struct {
+		pattern string
+		idx     int
+		file    string
+		tag     string
+		err     error
+		ok      bool
+	}
+	tcs := []tc{
+		{
+			`re:containers/(.*).log=/var/log/containers/*.log`,
+			1,
+			"/var/log/containers/azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.log",
+			"azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			nil,
+			true,
+		},
+		{
+			`re:(containers/)(?P<tag>.*)(.log)=/var/log/containers/*.log`,
+			2,
+			"/var/log/containers/azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.log",
+			"azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			nil,
+			true,
+		},
+		{
+			`re:containers/(?P<tag>.*)-.{64}\.log=/var/log/containers/*.log`,
+			1,
+			"/var/log/containers/azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.log",
+			"azure-ip-masq-agent-aaaaa_kube-system_azure-ip-masq-agent",
+			nil,
+			true,
+		},
+		{
+			`re:pods/[^/]+/([^/]+)/=/var/log/pods/*/*/*.log`,
+			1,
+			"/var/log/pods/kube-system_azure-ip-masq-agent-aaaaa_00000000-0000-0000-0000-000000000000/azure-ip-masq-agent/0.log",
+			"azure-ip-masq-agent",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.pattern, func(t *testing.T) {
+			t.Helper()
+
+			lfs, err := decodeLogFiles([]interface{}{tc.pattern})
+			if tc.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tc.err.Error())
+				return
+			}
+			assert.Len(t, lfs, 1)
+			lf := lfs[0]
+			assert.NotNil(t, lf.TagPattern)
+			assert.Equal(t, lf.TagMatchIndex, tc.idx)
+			tag, ok := lfs[0].TagFromFileName(tc.file)
+			if tc.ok {
+				assert.True(t, ok)
+				assert.Equal(t, tag, tc.tag)
+			} else {
+				assert.False(t, ok)
+			}
+		})
+	}
+}

--- a/examples/k8s.and.containerd/Dockerfile
+++ b/examples/k8s.and.containerd/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine AS builder
 
 WORKDIR $GOPATH/src/github.com/papertrail/remote_syslog2
 
-COPY ../.. .
+COPY . .
 
 RUN go get -v
 

--- a/examples/k8s.and.containerd/Dockerfile
+++ b/examples/k8s.and.containerd/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine AS builder
+
+WORKDIR $GOPATH/src/github.com/papertrail/remote_syslog2
+
+COPY ../.. .
+
+RUN go get -v
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o /remote_syslog2
+
+FROM scratch
+
+COPY --from=builder /remote_syslog2 /remote_syslog2
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+ENTRYPOINT [ "/remote_syslog2", "-D", "--tls" ]

--- a/examples/k8s.and.containerd/daemonset.yml
+++ b/examples/k8s.and.containerd/daemonset.yml
@@ -1,5 +1,12 @@
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: papertrail-destination
+stringData:
+  papertrail-destination: syslog+tls://SERVER:PORT
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: papertrail-remote-syslog
@@ -10,14 +17,6 @@ data:
       - re:containers/(?P<tag>.*)-.{64}\.log=/var/log/containers/*.log
     exclude_files:
       - .*papertrail-remote.*
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: papertrail-destination
-stringData:
-  papertrail-destination: syslog+tls://SERVER:PORT
-type: Opaque
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/examples/k8s.and.containerd/daemonset.yml
+++ b/examples/k8s.and.containerd/daemonset.yml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: papertrail-remote-syslog
+data:
+  domain: kubernetes.default.svc
+  config.yml: |
+    files:
+      - re:containers/(?P<tag>.*)-.{64}\.log=/var/log/containers/*.log
+    exclude_files:
+      - .*papertrail-remote.*
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: papertrail-destination
+stringData:
+  papertrail-destination: syslog+tls://SERVER:PORT
+type: Opaque
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: papertrail-remote-syslog2
+spec:
+  selector:
+    matchLabels:
+      name: papertrail-remote-syslog2
+  template:
+    metadata:
+      labels:
+        name: papertrail-remote-syslog2
+    spec:
+      imagePullSecrets:
+        - name: quay-secret
+      containers:
+        - resources:
+            requests:
+              cpu: 0.15
+            limits:
+              memory: 500Mi
+          env:
+            - name: "REMOTE_SYSLOG_DESTINATION.URI"
+              valueFrom:
+                secretKeyRef:
+                  name: papertrail-destination
+                  key: papertrail-destination
+            - name: "REMOTE_SYSLOG_CONFIG_FILE"
+              value: /config/config.yml
+            - name: "REMOTE_SYSLOG_HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "REMOTE_SYSLOG_DOMAIN"
+              valueFrom:
+                configMapKeyRef:
+                  name: papertrail-remote-syslog
+                  key: domain
+          image: quay.io/redsift/remote_syslog2:latest
+          name: remote-syslog
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: log
+              mountPath: /var/log
+      volumes:
+        - name: log
+          hostPath:
+              path: /var/log
+        - name: config
+          configMap:
+            name: papertrail-remote-syslog
+            items:
+            - key: "config.yml"
+              path: "config.yml"

--- a/remote_syslog.go
+++ b/remote_syslog.go
@@ -180,7 +180,6 @@ func (s *Server) globFiles(firstPass bool) {
 	log.Debugf("Evaluating file globs")
 	for _, glob := range s.config.Files {
 
-		tag := glob.Tag
 		files, err := filepath.Glob(utils.ResolvePath(glob.Path))
 
 		if err != nil {
@@ -206,6 +205,13 @@ func (s *Server) globFiles(firstPass bool) {
 				}
 
 				s.registry.Add(file)
+
+				tag, ok := glob.TagFromFileName(file)
+				if !ok {
+					log.Warningf("Tag pattern did not match file: %s, skipping", file)
+					continue
+				}
+
 				go s.tailOne(file, tag, whence)
 			}
 		}

--- a/remote_syslog_test.go
+++ b/remote_syslog_test.go
@@ -162,6 +162,7 @@ func testConfig() *Config {
 		Severity:             severity,
 		Facility:             facility,
 		Destination: struct {
+			URI      string
 			Host     string
 			Port     int
 			Protocol string


### PR DESCRIPTION
We faced the challenge to forward the containerd container logs from inside of an azure managed kubernetes cluster to papertrail. We tried fluentd and weren't very happy with the results. This is what we came up with.

Changes:
- Config option for a cluster domain, that is suffixed to the host name.
- Optional regular expression per glob pattern, to extract a meaningful "tag" from the file name.
- Example Dockerfile and kubernetes manifest
- Updated README