### PR TITLE
Get instance id using AWS IMDSv2

### DIFF
--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -34,8 +34,8 @@ files:
       #!/bin/bash
       logger_config="/etc/log_files.yml"
       appname=`{ "Ref" : "AWSEBEnvironmentName" }`
-      IMDS_TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-      instid=`curl -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id`
+      IMDS_TOKEN=`curl -s -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" http://169.254.169.254/latest/api/token`
+      instid=`curl -s -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id`
       myhostname=${appname}_${instid}
   
       if [ -f $logger_config ]; then

--- a/examples/remote_syslog.ebextensions.config
+++ b/examples/remote_syslog.ebextensions.config
@@ -34,7 +34,8 @@ files:
       #!/bin/bash
       logger_config="/etc/log_files.yml"
       appname=`{ "Ref" : "AWSEBEnvironmentName" }`
-      instid=`wget -q -O - http://169.254.169.254/latest/meta-data/instance-id`
+      IMDS_TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
+      instid=`curl -H "X-aws-ec2-metadata-token: $IMDS_TOKEN" http://169.254.169.254/latest/meta-data/instance-id`
       myhostname=${appname}_${instid}
   
       if [ -f $logger_config ]; then


### PR DESCRIPTION
Get the instance id with AWS's latest [instance metadata service (IMDSv2)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html). Otherwise, a http 401 error occurs.