### PR TITLE
Add granular severity settings for log_files.yml

### DIFF
--- a/config.go
+++ b/config.go
@@ -63,8 +63,9 @@ type Config struct {
 }
 
 type LogFile struct {
-	Path string
-	Tag  string
+	Path     string
+	Tag      string
+	Severity syslog.Priority
 }
 
 func init() {
@@ -309,18 +310,22 @@ func decodeLogFiles(f interface{}) ([]LogFile, error) {
 
 		case map[interface{}]interface{}:
 			var (
-				tag  string
-				path string
+				tag      string
+				path     string
+				severity syslog.Priority
 			)
 
 			tag, _ = val["tag"].(string)
 			path, _ = val["path"].(string)
 
+			severity_input, _ := val["severity"].(string)
+			severity, _ = syslog.Severity(severity_input)
+
 			if path == "" {
 				return files, fmt.Errorf("Invalid log file %#v", val)
 			}
 
-			files = append(files, LogFile{Tag: tag, Path: path})
+			files = append(files, LogFile{Tag: tag, Path: path, Severity: severity})
 
 		default:
 			panic(vals)

--- a/examples/log_files.yml.example.advanced
+++ b/examples/log_files.yml.example.advanced
@@ -6,6 +6,7 @@ files:
     tag: site2/access_log
   - path: /var/log/httpd/site2/error_log
     tag: site2/error_log
+    severity: err   # Note: valid severity includes: emerg, alert, crit, err, warn, notice, info, debug
   - /opt/misc/*.log
   - /home/**/*.log
   - /var/log/mysqld.log


### PR DESCRIPTION
This change will allow users to adjust the serverity send to remote servers for each log files.
So you can have one log file that send as warn, another log file send as info in the same config.

In the event the serverity is not provided, it fallbacks to the previous behavior

The change does not apply to command line parameter, Im not too sure about the syntax for the command line parameter. If someone can give me the full working example of how it works with tags on command line parameter, I'll be happy to put in a bit more time to get it working on command line parameter too.